### PR TITLE
Refactor `Copyable` trait to extend `Function`, introduce `derived` m…

### DIFF
--- a/src/alpaca/core/Copyable.scala
+++ b/src/alpaca/core/Copyable.scala
@@ -4,12 +4,8 @@ import scala.annotation.implicitNotFound
 import scala.deriving.Mirror
 
 @implicitNotFound("${T} should be a case class.")
-trait Copyable[T] {
-  def apply(t: T): T
-}
+trait Copyable[T] extends (T => T)
 
-//todo: tests https://github.com/halotukozak/alpaca/issues/54
 object Copyable {
-  // todo: replace with semi-auto derivation https://github.com/halotukozak/alpaca/issues/54
-  given [T <: Product: Mirror.ProductOf as m]: Copyable[T] = t => m.fromTuple(Tuple.fromProductTyped(t))
+  def derived[T <: Product: Mirror.ProductOf as m]: Copyable[T] = t => m.fromTuple(Tuple.fromProductTyped(t))
 }

--- a/src/alpaca/lexer/Lexer.scala
+++ b/src/alpaca/lexer/Lexer.scala
@@ -13,6 +13,7 @@ transparent inline given ctx(using c: AnyGlobalCtx): c.type = c
 
 type LexerDefinition[Ctx <: AnyGlobalCtx] = PartialFunction[String, Token[?, Ctx]]
 
+@experimental //for IJ  :/
 transparent inline def lexer[Ctx <: AnyGlobalCtx & Product](
   using Ctx WithDefault DefaultGlobalCtx[DefaultLexem[?]],
 )(
@@ -25,6 +26,7 @@ transparent inline def lexer[Ctx <: AnyGlobalCtx & Product](
 
 //todo: ctxManipulation should work
 //todo: more complex expressions should be supported in remaping
+@experimental//for IJ  :/
 private def lexerImpl[Ctx <: AnyGlobalCtx: Type](
   rules: Expr[Ctx ?=> LexerDefinition[Ctx]],
   copy: Expr[Copyable[Ctx]],

--- a/src/alpaca/lexer/context/GlobalCtx.scala
+++ b/src/alpaca/lexer/context/GlobalCtx.scala
@@ -1,6 +1,8 @@
 package alpaca.lexer.context
 
-import scala.annotation.unchecked.uncheckedVariance
+import alpaca.core.Copyable
+
+import scala.deriving.Mirror
 import scala.util.matching.Regex.Match
 
 type AnyGlobalCtx = GlobalCtx[?]
@@ -17,3 +19,7 @@ trait GlobalCtx[LexemTpe <: Lexem[?]] {
 
   def text_=(t: CharSequence): Unit = _text = t
 }
+
+object GlobalCtx:
+  given [LexemTpe <: Lexem[?], Ctx <: GlobalCtx[LexemTpe] & Product: Mirror.ProductOf]: Copyable[Ctx] =
+    Copyable.derived

--- a/src/alpaca/lexer/context/default/DefaultLexem.scala
+++ b/src/alpaca/lexer/context/default/DefaultLexem.scala
@@ -1,6 +1,8 @@
-package alpaca.lexer
-package context
-package default
+package alpaca.lexer.context.default
+
+import alpaca.core.Copyable
+import alpaca.lexer.ValidName
+import alpaca.lexer.context.Lexem
 
 final case class DefaultLexem[Name <: ValidName](
   name: Name,

--- a/src/alpaca/lexer/context/default/globalCtx.scala
+++ b/src/alpaca/lexer/context/default/globalCtx.scala
@@ -5,7 +5,6 @@ final case class EmptyGlobalCtx[LexemTpe <: Lexem[?]](
   var lastLexem: LexemTpe | Null = null,
   protected var _text: CharSequence = "",
 ) extends GlobalCtx[LexemTpe]
-// derives Copyable todo: https://github.com/halotukozak/alpaca/issues/54
 // derives Empty todo: https://github.com/halotukozak/alpaca/issues/53l
 final case class DefaultGlobalCtx[LexemTpe <: Lexem[?]](
   var lastLexem: LexemTpe | Null = null,
@@ -13,5 +12,4 @@ final case class DefaultGlobalCtx[LexemTpe <: Lexem[?]](
   var position: Int = 0,
 ) extends GlobalCtx[LexemTpe]
     with PositionTracking
-// derives Copyable todo: https://github.com/halotukozak/alpaca/issues/54
 // derives Empty todo: https://github.com/halotukozak/alpaca/issues/53l

--- a/test/src/alpaca/core/CopyableTest.scala
+++ b/test/src/alpaca/core/CopyableTest.scala
@@ -1,0 +1,67 @@
+package alpaca.core
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import scala.compiletime.testing.typeChecks
+
+final class CopyableTest extends AnyFunSuite with Matchers {
+
+  inline def copy[T]: Copyable[T] = compiletime.summonInline[Copyable[T]]
+
+  case class Person(name: String, age: Int) derives Copyable
+
+  case class Address(city: String, zip: Int) derives Copyable
+
+  case class User(person: Person, address: Address, tags: List[String], opt: Option[Int], tuple: (Int, String))
+    derives Copyable
+
+  case class Box[T](value: T) derives Copyable
+
+  case class Defaults(a: Int = 1, b: String = "x") derives Copyable
+
+  case class Empty() derives Copyable
+
+  test("derived produces an identity-like function for a simple case class") {
+    val p = Person("Ann", 30)
+    copy(p) shouldEqual p
+  }
+
+  test("derived works with nested case classes, options, lists and tuples") {
+    val u = User(
+      person = Person("Bob", 25),
+      address = Address("NYC", 10001),
+      tags = List("a", "b"),
+      opt = Some(7),
+      tuple = (42, "answer"),
+    )
+    copy(u) shouldEqual u
+  }
+
+  test("derived works for a generic case class instantiation") {
+    val bx = Box(Person("Cara", 22))
+    copy(bx) shouldEqual bx
+  }
+
+  test("derived handles default parameters and zero-arity case class") {
+    val d = Defaults()
+    val e = Empty()
+
+    copy(d) shouldEqual d
+    copy(e) shouldEqual e
+  }
+
+  test("cannot derive Copyable for non-case classes or non-product types (compile-time)") {
+    // String is not a case class => should not typecheck
+    typeChecks("import alpaca.core.Copyable; val c = Copyable.derived[String]") shouldBe false
+
+    // Define a plain (non-case) class and try to derive should fail
+    val code =
+      """
+        |import alpaca.core.Copyable
+        |class Regular(val x: Int)
+        |val c = Copyable.derived[Regular]
+        |""".stripMargin
+    typeChecks(code) shouldBe false
+  }
+}


### PR DESCRIPTION
…ethod, and add tests for case class derivation. Annotate `lexer` and `lexerImpl` as experimental. Update context types to support `Copyable`.