### PR TITLE
Refactor `Lexer`, `Empty`, and `Copyable` tests to use `shouldNot com…

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -55,8 +55,6 @@ object `package` extends ScalaModule with ScoverageModule {
   def alpacaVersion = "0.1.0"
 
   object test extends ScalaTests with TestModule.ScalaTest with ScoverageTests {
-    def mvnDeps = Seq(
-      mvn"org.scalatest::scalatest:3.2.19",
-    )
+    def scalaTestVersion = "3.2.19"
   }
 }

--- a/test/src/alpaca/core/CopyableTest.scala
+++ b/test/src/alpaca/core/CopyableTest.scala
@@ -56,12 +56,10 @@ final class CopyableTest extends AnyFunSuite with Matchers {
     typeChecks("import alpaca.core.Copyable; val c = Copyable.derived[String]") shouldBe false
 
     // Define a plain (non-case) class and try to derive should fail
-    val code =
-      """
-        |import alpaca.core.Copyable
-        |class Regular(val x: Int)
-        |val c = Copyable.derived[Regular]
-        |""".stripMargin
-    typeChecks(code) shouldBe false
+    """
+      |import alpaca.core.Copyable
+      |class Regular(val x: Int)
+      |val c = Copyable.derived[Regular]
+      |""".stripMargin shouldNot compile
   }
 }

--- a/test/src/alpaca/core/EmptyTest.scala
+++ b/test/src/alpaca/core/EmptyTest.scala
@@ -3,8 +3,6 @@ package alpaca.core
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-import scala.compiletime.testing.typeChecks
-
 final class EmptyTest extends AnyFunSuite with Matchers {
 
   inline def empty[T]: Empty[T] = compiletime.summonInline[Empty[T]]
@@ -39,20 +37,16 @@ final class EmptyTest extends AnyFunSuite with Matchers {
   }
 
   test("cannot derive Empty when any parameter lacks a default (compile-time)") {
-    val code =
-      """
-        |import alpaca.core.Empty
-        |case class Mixed(a: Int, b: String = "b") derives Empty
-        |""".stripMargin
-    typeChecks(code) shouldBe false
+    """
+      |import alpaca.core.Empty
+      |case class Mixed(a: Int, b: String = "b") derives Empty
+      |""".stripMargin shouldNot compile
   }
 
   test("cannot derive Empty for non-case classes (compile-time)") {
-    val code =
-      """
-        |import alpaca.core.Empty
-        |class Regular(val x: Int) derives Empty
-        |""".stripMargin
-    typeChecks(code) shouldBe false
+    """
+      |import alpaca.core.Empty
+      |class Regular(val x: Int) derives Empty
+      |""".stripMargin shouldNot compile
   }
 }

--- a/test/src/alpaca/core/ShowableTest.scala
+++ b/test/src/alpaca/core/ShowableTest.scala
@@ -1,8 +1,9 @@
 package alpaca.core
 
 import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
 
-final class ShowableTest extends AnyFunSuite {
+final class ShowableTest extends AnyFunSuite with Matchers {
 
   test("Showable should convert String to Shown") {
     val str = "Hello, World!"
@@ -38,14 +39,12 @@ final class ShowableTest extends AnyFunSuite {
   }
 
   test("Showable should not convert unsupported types") {
-    assertDoesNotCompile(
-      """|
-         |import Showable._
-         |class UnsupportedType(val value: String)
-         |
-         |val unsupported: UnsupportedType = new UnsupportedType("Unsupported")
-         |val shown: String = show"$unsupported"
-         |""".stripMargin,
-    )
+    """|
+       |import Showable._
+       |class UnsupportedType(val value: String)
+       |
+       |val unsupported: UnsupportedType = new UnsupportedType("Unsupported")
+       |val shown: String = show"$unsupported"
+       |""".stripMargin shouldNot compile
   }
 }

--- a/test/src/alpaca/lexer/LexerApiTest.scala
+++ b/test/src/alpaca/lexer/LexerApiTest.scala
@@ -50,45 +50,46 @@ final class LexerApiTest extends AnyFunSuite with Matchers {
     // )
     //format: on
 
-    // Lexer.<
-    // Lexer.>
-    // Lexer.`=`
-    // Lexer.+
-    // Lexer.-
-    // Lexer.*
-    // Lexer./
-    // Lexer.`(`
-    // Lexer.`)`
-    // Lexer.`[`
-    // Lexer.`]`
-    // Lexer.`{`
-    // Lexer.`}`
-    // Lexer.`:`
-    // Lexer.`'`
-    // Lexer.`,`
-    // Lexer.`;`
-    // Lexer.dotAdd
-    // Lexer.dotSub
-    // Lexer.dotMul
-    // Lexer.dotDiv
-    // Lexer.lessEqual
-    // Lexer.greaterEqual
-    // Lexer.notEqual
-    // Lexer.equal
-    // Lexer.float
-    // Lexer.int
-    // Lexer.string
-    // Lexer.`if`
-    // Lexer.`else`
-    // Lexer.`for`
-    // Lexer.`while`
-    // Lexer.break
-    // Lexer.continue
-    // Lexer.`return`
-    // Lexer.eye
-    // Lexer.zeros
-    // Lexer.ones
-    // Lexer.print
-    // Lexer.id
+    // we check if compiles and not crashes
+    Lexer.<
+    Lexer.>
+    Lexer.`=`
+    Lexer.+
+    Lexer.-
+    Lexer.*
+    Lexer./
+    Lexer.`(`
+    Lexer.`)`
+    Lexer.`[`
+    Lexer.`]`
+    Lexer.`{`
+    Lexer.`}`
+    Lexer.`:`
+    Lexer.`'`
+    Lexer.`,`
+    Lexer.`;`
+    Lexer.dotAdd
+    Lexer.dotSub
+    Lexer.dotMul
+    Lexer.dotDiv
+    Lexer.lessEqual
+    Lexer.greaterEqual
+    Lexer.notEqual
+    Lexer.equal
+    Lexer.float
+    Lexer.int
+    Lexer.string
+    Lexer.`if`
+    Lexer.`else`
+    Lexer.`for`
+    Lexer.`while`
+    Lexer.break
+    Lexer.continue
+    Lexer.`return`
+    Lexer.eye
+    Lexer.zeros
+    Lexer.ones
+    Lexer.print
+    Lexer.id
   }
 }


### PR DESCRIPTION
…pile` for compile-time checks; clean up unused imports and adjust Mill build for `scalatest` dependency versioning.