### PR TITLE
fix: support multiline actions in parser rules

### DIFF
--- a/src/alpaca/internal/internal.scala
+++ b/src/alpaca/internal/internal.scala
@@ -45,7 +45,7 @@ private[internal] final class ReplaceRefs[Q <: Quotes](using val quotes: Q)(usin
     logger.trace(show"creating ReplaceRefs with ${queries.size} queries")
     new TreeMap:
       // skip NoSymbol
-      private val filtered = queries.filter(!_.find.isNoSymbol)
+      private val filtered = queries.filterNot(_.find.isNoSymbol)
 
       override def transformTerm(tree: Term)(owner: Symbol): Term =
         filtered
@@ -53,7 +53,11 @@ private[internal] final class ReplaceRefs[Q <: Quotes](using val quotes: Q)(usin
             case (find, replace) if find == tree.symbol =>
               logger.trace(show"replacing reference to $find with $replace")
               replace
-          .getOrElse(super.transformTerm(tree)(owner))
+          .getOrElse:
+            val tree1 = tree match
+              case block: Block => block.changeOwner(owner)
+              case block => block
+            super.transformTerm(tree1)(owner)
 
 /**
  * A helper for creating lambda expressions during macro expansion.

--- a/test/src/alpaca/integration/Bug148Test.scala
+++ b/test/src/alpaca/integration/Bug148Test.scala
@@ -1,0 +1,54 @@
+package alpaca
+package integration
+
+import alpaca.*
+import org.scalatest.funsuite.AnyFunSuite
+
+final class Bug148Test extends AnyFunSuite:
+  test("multiline action in parser rule - single production") {
+    val BugLexer = lexer:
+      case "T" => Token["T"]
+
+    object Bug extends Parser:
+      override val root: Rule[Any] = rule:
+        case BugLexer.T(_) =>
+          val x = 1
+          x
+
+    val (_, lexemes) = BugLexer.tokenize("T")
+    val (_, result) = Bug.parse(lexemes)
+    assert(result == 1)
+  }
+
+  test("multiline action in parser rule - multiple productions") {
+    val BugLexer = lexer:
+      case "\\s+" => Token.Ignored
+      case x @ "[0-9]+" => Token["num"](x.toInt)
+      case "\\+" => Token["+"]
+
+    object Bug extends Parser:
+      val Expr: Rule[Int] = rule(
+        "add" {
+          case (Expr(a), BugLexer.`+`(_), Expr(b)) =>
+            val sum = a + b
+            sum
+        },
+        {
+          case BugLexer.num(n) =>
+            val v = n.value
+            v
+        },
+      )
+      override val root: Rule[Int] = rule:
+        case Expr(v) =>
+          val result = v * 2
+          result
+
+      override val resolutions = Set(
+        production.add.before(BugLexer.`+`),
+      )
+
+    val (_, lexemes) = BugLexer.tokenize("1 + 2")
+    val (_, result) = Bug.parse(lexemes)
+    assert(result == 6) // (1 + 2) * 2
+  }


### PR DESCRIPTION
## Summary
- Fix `ReplaceRefs` TreeMap to re-own `Block` definitions to the correct lambda method symbol, preventing `NoSuchElementException` during lambda lifting when parser rule actions contain local variable definitions
- Add integration tests covering single and multiple production multiline actions

Closes #148

## Test plan
- [x] `Bug148Test` - single production with multiline action (`val x = 1; x`)
- [x] `Bug148Test` - multiple productions with multiline actions using bound pattern variables (`val sum = a + b; sum`)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)