### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - '**'
   workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   publish-artifacts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/halotukozak/alpaca/security/code-scanning/1](https://github.com/halotukozak/alpaca/security/code-scanning/1)

Add an explicit `permissions` block to `.github/workflows/publish.yml`.  
Best fix: define workflow-level minimal permissions so all jobs inherit them unless overridden. For this file, add:

```yaml
permissions:
  contents: read
```

Place it at the root (after `on:` section and before `jobs:`), preserving current behavior while explicitly constraining `GITHUB_TOKEN`. No imports, methods, or extra definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
