### PR TITLE
Fix incorrect examples and stale comments in docs

### DIFF
--- a/docs/_docs/between-stages.md
+++ b/docs/_docs/between-stages.md
@@ -69,12 +69,11 @@ object IndentTracking:
 
 // Step 3: Case class extends both
 case class MyCtx(
-  var text: CharSequence = "",
   var indentLevel: Int = 0,
 ) extends LexerCtx with IndentTracking
 
 // Step 4: Pass MyCtx to lexer -- auto composition happens at compile time
-valLexer = lexer[MyCtx]:
+val Lexer = lexer[MyCtx]:
   case "\\n" => Token.Ignored
   case id @ "[a-z]+" => Token["ID"](id)
 ```

--- a/docs/_docs/context-management.md
+++ b/docs/_docs/context-management.md
@@ -28,8 +28,7 @@ You can define a custom context by extending `LexerCtx` (and optionally `LineTra
 import alpaca.*
 
 case class MyCtx(
-  var text: CharSequence = "",
-  var braceDepth: Int = 0
+  var braceDepth: Int = 0,
 ) extends LexerCtx
 
 val myLexer = lexer[MyCtx]:

--- a/docs/_docs/guides/conflict-resolution.md
+++ b/docs/_docs/guides/conflict-resolution.md
@@ -109,6 +109,8 @@ Expr + Expr + ...
 Consider marking production Expr -> Expr + Expr to be alwaysBefore or alwaysAfter "+"
 ```
 
+> **Note:** The error message says `alwaysBefore`/`alwaysAfter`. These method names do not exist in the Alpaca API. The correct methods are `before` and `after`. See [Conflict Resolution](../conflict-resolution.md) for full details.
+
 ### How to read it:
 
 1. **The Conflict**: It tells you exactly which actions are clashing (Shift `+` vs Reduce `Expr`).

--- a/docs/_docs/guides/contextual-parsing.md
+++ b/docs/_docs/guides/contextual-parsing.md
@@ -19,7 +19,6 @@ import alpaca.*
 import scala.collection.mutable
 
 case class BraceCtx(
-  var text: CharSequence = "",
   stack: mutable.Stack[String] = mutable.Stack()
 ) extends LexerCtx
 
@@ -76,53 +75,6 @@ object MyParser extends Parser[SymbolTableCtx]:
       ctx.symbols += (id.value -> tpe.value)
 ```
 
-[//]: # (todo: ten przyklad nie dziala)
-[//]: # (## 4. Mode Switching &#40;Lexical Feedback&#41;)
-
-[//]: # ()
-[//]: # (Sometimes you need to change how the lexer behaves based on what it just matched. For example, tracking whether)
-
-[//]: # (you are inside a string literal to lex its content differently.)
-
-[//]: # ()
-[//]: # (While Alpaca doesn't support real-time feedback from the parser to the lexer &#40;since the lexer finishes first&#41;, you can)
-
-[//]: # (implement modes within the lexer using context state. The context state is checked in rule bodies — not as pattern guards)
-
-[//]: # (— since Alpaca patterns are matched by the generated scanner at compile time, not at runtime.)
-
-[//]: # ()
-[//]: # (```scala sc:nocompile)
-
-[//]: # (import alpaca.*)
-
-[//]: # ()
-[//]: # (case class ModeCtx&#40;)
-
-[//]: # (  var text: CharSequence = "",)
-
-[//]: # (  var inString: Boolean = false,)
-
-[//]: # (&#41; extends LexerCtx)
-
-[//]: # ()
-[//]: # (val ModeLexer = lexer[ModeCtx]:)
-
-[//]: # (  case "\"" =>)
-
-[//]: # (    ctx.inString = !ctx.inString)
-
-[//]: # (    Token["QUOTE"])
-
-[//]: # (  case content @ "[^\"]+" =>)
-
-[//]: # (    if ctx.inString then Token["STRING_CONTENT"]&#40;content&#41;)
-
-[//]: # (    else Token["TEXT"]&#40;content&#41;)
-
-[//]: # (  case "\\s+" => Token.Ignored)
-
-[//]: # (```)
 
 ## 5. The `BetweenStages` Hook
 

--- a/docs/_docs/guides/lexer-error-handling.md
+++ b/docs/_docs/guides/lexer-error-handling.md
@@ -40,9 +40,9 @@ You can use a custom `LexerCtx` to track the number of errors encountered during
 import alpaca.*
 
 case class ErrorCtx(
-  var text: CharSequence = "",
-  var errorCount: Int = 0
-) extends LexerCtx
+  var errorCount: Int = 0,
+  var position: Int = 1,
+) extends LexerCtx with PositionTracking
 
 val myLexer = lexer[ErrorCtx]:
   case "[a-z]+" => Token["ID"]

--- a/docs/_docs/index.md
+++ b/docs/_docs/index.md
@@ -155,7 +155,6 @@ import alpaca.*
 import scala.collection.mutable.Stack
 
 case class BraceContext(
-  var text: CharSequence = "",
   val braces: Stack[Char] = Stack()
 ) extends LexerCtx
 

--- a/docs/_docs/lexer-context.md
+++ b/docs/_docs/lexer-context.md
@@ -35,11 +35,12 @@ The snapshot in each lexeme captures the values *after* the token was consumed, 
 ## The LexerCtx Trait
 
 `LexerCtx` is the base trait for all lexer contexts.
-Any custom context must satisfy three rules:
+Any custom context must satisfy two rules:
 
-1. **It must be a case class** -- `LexerCtx` has a `this: Product =>` self-type, and the auto-derivation machinery requires a `Product` instance. Regular classes do not work (yet?).
-2. **It must include `var text: CharSequence = ""`** -- `LexerCtx` declares this field as abstract. The lexer sets it to the remaining input before each match. Forgetting it produces a compile error.
-3. **All fields must have default values** -- The `Empty[T]` derivation macro reads default parameter values from the companion object to construct the initial context. If any parameter lacks a default, the macro fails at compile time.
+1. **It must be a case class** -- `LexerCtx` has a `this: Product =>` self-type, and the auto-derivation machinery requires a `Product` instance. Regular classes do not work.
+2. **All fields must have default values** -- The `Empty[T]` derivation macro reads default parameter values from the companion object to construct the initial context. If any parameter lacks a default, the macro fails at compile time.
+
+> **Warning:** Do not declare `var text`, `var lastLexeme`, or `var lastRawMatched` in your case class. These fields are provided by the `LexerCtx` trait and managed internally by the lexer. Redeclaring them shadows the internal fields and breaks tokenization.
 
 Mutable state fields must be `var`, not `val` -- the lexer assigns to them directly.
 Exception: a field of a mutable collection type (e.g., `scala.collection.mutable.Stack`) can be `val` because you mutate the collection itself, not the reference.
@@ -52,8 +53,7 @@ To track additional state, define a case class extending `LexerCtx` with your ex
 import alpaca.*
 
 case class StateCtx(
-  var text: CharSequence = "",   // required
-  var count: Int = 0,            // custom state
+  var count: Int = 0,
 ) extends LexerCtx
 
 val Lexer = lexer[StateCtx]:
@@ -83,7 +83,6 @@ You can read and write any `var` field on it:
 import alpaca.*
 
 case class IndentCtx(
-  var text: CharSequence = "",
   var indent: Int = 0,
   var depth: Int = 0,
 ) extends LexerCtx
@@ -136,7 +135,6 @@ For custom contexts, all case class fields appear in the snapshot:
 import alpaca.*
 
 case class MyCtx(
-  var text: CharSequence = "",
   var count: Int = 0,
 ) extends LexerCtx
 

--- a/docs/_docs/lexer-error-recovery.md
+++ b/docs/_docs/lexer-error-recovery.md
@@ -66,7 +66,6 @@ The workaround is to move the condition inside the rule body, after the match:
 import alpaca.*
 
 case class MyCtx(
-  var text: CharSequence = "",
   var someCondition: Boolean = false,
 ) extends LexerCtx
 

--- a/docs/_docs/lexer.md
+++ b/docs/_docs/lexer.md
@@ -237,7 +237,6 @@ You can define a custom context for stateful lexing (tracking indentation, nesti
 import alpaca.*
 
 case class IndentCtx(
-  var text: CharSequence = "",
   var indent: Int = 0,
 ) extends LexerCtx
 

--- a/docs/_docs/theory/tokens.md
+++ b/docs/_docs/theory/tokens.md
@@ -39,13 +39,10 @@ The word *lexeme* is used throughout this documentation to mean this complete re
 In Alpaca, each matched token is represented as a `Lexeme[Name, Value]`. A lexeme carries four
 pieces of information:
 
-^ todo: it also carries the context
-
 - `name` — the token class name string, e.g., `"NUMBER"` or `"PLUS"`
-- `value` — the extracted value with its Scala type, e.g., `3.14: Double` for NUMBER, `(): Unit`
+- `value` — the extracted value with its Scala type, e.g., `3.14: Double` for NUMBER, `"+": String`
   for PLUS
-- `position` — the character offset at the end of the match
-- `line` — the line number at the end of the match
+- `fields` — a snapshot of the lexer context at match time, accessible as typed fields (e.g., `.position`, `.line`, `.text`)
 
 The tokenization output for a simple expression illustrates this:
 
@@ -68,8 +65,6 @@ Whitespace matches `Token.Ignored` and does not produce a lexeme — it disappea
 ## CalcLexer Token Class Table
 
 The `CalcLexer` running example defines seven token classes:
-
-^ todo: come up a with better example
 
 | Token Class | Regex Pattern       | Value Type | Example Match     |
 |-------------|---------------------|------------|-------------------|

--- a/docs/_docs/tutorials/extractors.md
+++ b/docs/_docs/tutorials/extractors.md
@@ -22,7 +22,7 @@ case MyLexer.NUM(n) => n.value // n is a Lexem object
 The `Lexem` object contains:
 - `value`: The extracted value (e.g., `Double`, `Int`, `String`).
 - `name`: The name of the token.
-- `fields`: A NamedTuple containing context information (like `line` and `position`). //todo: to juz nieaktualne
+- `fields`: A map containing context field snapshots (like `line` and `position`). Access fields directly via `n.line`, `n.position`, etc.
 
 ### Accessing Context Fields
 You can match directly on context fields if they are available in your lexer context. If such fields are not defined in your custom context, your code will not compile, ensuring type safety.
@@ -71,9 +71,7 @@ case (MyLexer.IF(_), Expr(cond), MyLexer.THEN(_), Stmt(s)) => ...
 
 ## How it Works (Internal)
 
-//ta sekcja pewnie powinna byc jakos ujednolicona
-
-Alpaca's macros analyze these pattern matches at compile-time to:
+Alpaca's macros analyze these pattern matches at compile time to:
 1. Identify the symbols (terminals and non-terminals) involved.
 2. Construct the grammar's production rules.
 3. Generate the parse table.


### PR DESCRIPTION
## Summary
- Remove `var text: CharSequence` from all custom `LexerCtx` examples — this field is provided by the `LexerCtx` trait and must not be redeclared by users
- Update LexerCtx rules from 3 to 2 in `lexer-context.md`, add warning about internal fields (`text`, `lastLexeme`, `lastRawMatched`)
- Fix `valLexer` typo in `between-stages.md`
- Add `alwaysBefore`/`alwaysAfter` API disclaimer to `guides/conflict-resolution.md`
- Fix `ErrorCtx` to extend `PositionTracking` (was using `ctx.position` without the trait)
- Remove Polish-language TODO comments from `tutorials/extractors.md` and `guides/contextual-parsing.md`
- Fix stale TODO comments in `theory/tokens.md`
- Remove commented-out Mode Switching section from `guides/contextual-parsing.md`

## Test plan
- [ ] Verify all code snippets in changed files are consistent with the actual `LexerCtx` API
- [ ] Confirm no remaining `var text` in user-defined context examples
- [ ] Confirm no remaining Polish-language comments or TODO markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)