### PR TITLE
Fix OnTokenMatch data flow description and deduplicate token-ignored note

### DIFF
--- a/docs/_docs/on-token-match.md
+++ b/docs/_docs/on-token-match.md
@@ -94,9 +94,10 @@ See the [Lexer Context](lexer-context.md) page for the full reference on `OnToke
 Each call to `tokenize()` follows this sequence:
 
 1. The lexer attempts to match the remaining input against each rule pattern in order. The first match wins. If no pattern matches, a `RuntimeException` is thrown with the unexpected character.
-2. `OnTokenMatch` runs: it advances the text cursor (`ctx.text`), applies any rule-body context changes that ran before it was called, and takes a snapshot of all context fields.
-3. If the matched token is a `DefinedToken` (any `Token["NAME"]` with or without a value), a `Lexeme` is constructed with the token's name, value, and the snapshot, then appended to the output list.
-4. If the matched token is `Token.Ignored`, `OnTokenMatch` still runs (keeping position, line, and custom counters current) but no `Lexeme` is produced. The token is invisible to the parser.
+2. `Tokenization.tokenize` advances the text cursor (`ctx.text`) past the matched string and records the matched text in `ctx.lastRawMatched`.
+3. `OnTokenMatch` runs. The default `OnTokenMatch[LexerCtx]` applies any rule-body context changes (`modifyCtx`), derives a snapshot from the context's `Product` elements (case class fields), overrides the snapshot's `text` field with the matched string, and — for `DefinedToken`s — builds a `Lexeme` from the token name, value, and snapshot.
+4. If the matched token is `Token.Ignored` (or a recovery token), `OnTokenMatch` still runs the context modifications and tracking updates but does not emit a `Lexeme`. The token is invisible to the parser.
+5. Tracking hooks (`PositionTracking`, `LineTracking`, custom traits) run as part of the composed `OnTokenMatch`, updating `position`, `line`, etc.
 5. This repeats until the entire input is consumed. `tokenize()` then returns the named tuple `(ctx, lexemes)` -- the final context state and the complete lexeme list.
 6. `parse(lexemes)` receives the list, appends `Lexeme.EOF` internally, and runs the parser grammar against the sequence.
 

--- a/docs/_docs/theory/tokens.md
+++ b/docs/_docs/theory/tokens.md
@@ -60,7 +60,7 @@ val (_, lexemes) = BrainLexer.tokenize("foo(++)")
 //   .line     — line number at end of match
 ```
 
-Whitespace matches `Token.Ignored` and does not produce a lexeme — it disappears from the stream.
+Input matched as `Token.Ignored` — such as whitespace or other non-command characters — does not produce a lexeme and disappears from the stream.
 
 ## BrainLexer Token Class Table
 
@@ -80,8 +80,6 @@ The `BrainLexer` running example defines these token classes:
 | `functionOpen` | `\(`          | `Unit`     | `"("`                |
 | `functionClose`| `\)`          | `Unit`     | `")"`                |
 | `functionCall` | `!`           | `Unit`     | `"!"`                |
-
-Input matched as `Token.Ignored` -- such as whitespace or other non-command characters -- does not produce a lexeme and disappears from the stream.
 
 `functionName` is the only value-bearing token: the `@` binding captures the matched text and passes it to `Token["functionName"](name)`. The other tokens use `Token["NAME"]` without a value argument — they carry `Unit`. Their presence in the stream is enough; the matched text is accessible via `lexeme.text` from the context snapshot if needed.
 


### PR DESCRIPTION
## Summary

Follow-up fixes addressing review comments left on already-merged doc PRs that weren't fully resolved in the subsequent rounds.

- **on-token-match.md Data Flow**: The sequence incorrectly said \`OnTokenMatch\` advances the text cursor. Per the implementation, \`Tokenization.tokenize\` advances \`ctx.text\` and sets \`lastRawMatched\` *before* \`OnTokenMatch\` runs; the hook then applies rule-body context changes, derives the snapshot, and emits a \`Lexeme\` only for \`DefinedToken\`s (not \`Token.Ignored\`). (From PR #353 review.)
- **theory/tokens.md**: The "Token.Ignored" note appeared twice — removed the short intro one and kept the detailed one. (From PR #356 review.)

## Test plan
- [ ] \`./mill docJar\` passes
- [ ] Description matches actual implementation in \`Tokenization.scala\` and \`OnTokenMatch.scala\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)