### PR TITLE
Documentation audit fixes

### DIFF
--- a/docs/_docs/cookbook/contextual-lexing.md
+++ b/docs/_docs/cookbook/contextual-lexing.md
@@ -91,12 +91,12 @@ object BrainParser extends Parser[BrainParserCtx]:
   val FunctionDef: Rule[BrainAST] = rule:
     case (BrainLexer.functionName(name), BrainLexer.functionOpen(_),
           Operation.List(ops), BrainLexer.functionClose(_)) =>
-      require(ctx.functions.add(name.value), s"Function ${name.value} already defined")
+      require(ctx.functions.add(name.value), s"Function ${name.value} is already defined")
       BrainAST.FunctionDef(name.value, ops)
 
   val FunctionCall: Rule[BrainAST] = rule:
     case (BrainLexer.functionName(name), BrainLexer.functionCall(_)) =>
-      require(ctx.functions.contains(name.value), s"Function ${name.value} not defined")
+      require(ctx.functions.contains(name.value), s"Function ${name.value} is not defined")
       BrainAST.FunctionCall(name.value)
 
   // ... other rules

--- a/docs/_docs/extractors.md
+++ b/docs/_docs/extractors.md
@@ -127,7 +127,7 @@ The user-visible fields are:
 - **`name: String`** — the token type name (e.g., `"NUMBER"`, `"PLUS"`)
 - **`value: T`** — the extracted value; the type depends on the `Token["NAME"](value)` definition in the lexer
 - **`text: String`** — the raw matched characters; always a `String` regardless of token type
-- **`position: Int`** — character position at match time (post-match; incremented by token length before the snapshot)
+- **`position: Int`** — 1-based column within the current line at match time (post-match; resets on newlines)
 - **`line: Int`** — line number at match time
 - **`fields: Map[String, Any]`** — all context fields at match time, accessible by name
 

--- a/docs/_docs/on-token-match.md
+++ b/docs/_docs/on-token-match.md
@@ -7,7 +7,7 @@ The `OnTokenMatch` hook is responsible for advancing the text cursor, constructi
 
 Most programs need nothing more than this:
 
-```scala sc:nocompile sc-compile-with:BrainLexer.scala,BrainParser.scala
+```scala sc:nocompile
 val (ctx, lexemes) = BrainLexer.tokenize("[>+<-]")
 val (_, ast) = BrainParser.parse(lexemes)
 ```

--- a/docs/_docs/parser-context.md
+++ b/docs/_docs/parser-context.md
@@ -103,7 +103,7 @@ The initial context is created once per `parse()` call. There is no per-rule cop
 ```scala sc:nocompile
 { case BrainLexer.functionName(name) =>
     val funcName = name.value      // String -- the function name
-    val pos = name.position        // Int -- character position from lexer
+    val pos = name.position        // Int -- 1-based column within the line
     val ln = name.line             // Int -- line number from lexer
     // ...
 }

--- a/src/alpaca/internal/lexer/Tokenization.scala
+++ b/src/alpaca/internal/lexer/Tokenization.scala
@@ -44,11 +44,11 @@ transparent abstract class Tokenization[Ctx <: LexerCtx](
    * Tokenizes the input character sequence.
    *
    * Processes the input from start to finish, matching tokens and building
-   * a list of lexems. Throws a RuntimeException if an unexpected character
+   * a list of lexemes. Throws a RuntimeException if an unexpected character
    * is encountered.
    *
    * @param input the input to tokenize
-   * @return a list of lexems representing the tokenized input
+   * @return a tuple of (ctx, lexemes) where ctx is the final lexer context and lexemes is the list of matched tokens
    */
   final def tokenize(input: CharSequence): (ctx: Ctx, lexemes: List[Lexeme]) =
     val globalCtx = empty()

--- a/src/alpaca/lexer.scala
+++ b/src/alpaca/lexer.scala
@@ -133,7 +133,7 @@ object LexerCtx:
    *
    * This implementation:
    * - Updates lastRawMatched with the matched text
-   * - Creates a new Lexem for defined tokens
+   * - Creates a new Lexeme for defined tokens
    * - Advances the text position
    * - Applies any context modifications
    */


### PR DESCRIPTION
## Summary

Comprehensive audit of all documentation and scaladocs after the doc overhaul merge chain completed.

**Docs:**
- Remove broken `sc-compile-with:BrainLexer.scala,BrainParser.scala` from `on-token-match.md` (eliminates 4 docJar warnings)
- Fix error message strings in `cookbook/contextual-lexing.md` to match source ("is already defined" / "is not defined")
- Fix `position` description in `extractors.md` and `parser-context.md` to consistently say "1-based column within the current line" instead of generic "character position"

**Scaladocs:**
- Fix typo "Lexem" → "Lexeme" in `lexer.scala` OnTokenMatch scaladoc
- Fix `@return` in `Tokenization.scala` to describe `(ctx, lexemes)` tuple, not just "list of lexems"

## Audit results

All clear on:
- Sidebar ↔ filesystem consistency (31/31 pages)
- Cross-links (130 links, 0 broken)
- No stale references to renamed files (between-stages.md, contextual-parsing.md)
- BrainFuck token names consistent across all pages
- CalcLexer token names consistent (NUMBER, TIMES, etc.)
- No remaining BetweenStages references
- No `derives Copyable` in docs
- `./mill compile` ✓, `./mill test` ✓ (186/186), `./mill docJar` ✓

## Test plan
- [x] `./mill compile` passes
- [x] `./mill test` passes (186 tests, clean build)
- [x] `./mill docJar` passes with no errors and no snippet warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)