### PR TITLE
perf: O(1) state deduplication in LR table construction

### DIFF
--- a/src/alpaca/internal/parser/ParseTable.scala
+++ b/src/alpaca/internal/parser/ParseTable.scala
@@ -73,15 +73,16 @@ private[parser] object ParseTable:
     val firstSet = FirstSet(productions)
     logger.trace("building states and parse table...")
     var currStateId = 0
-    val states =
-      mutable.ListBuffer(
-        State.fromItem(
-          State.empty,
-          productions.find(_.lhs == parser.Symbol.Start).get.toItem(),
-          productions,
-          firstSet,
-        ),
-      )
+    val initialState = State.fromItem(
+      State.empty,
+      productions.find(_.lhs == parser.Symbol.Start).get.toItem(),
+      productions,
+      firstSet,
+    )
+    val states = mutable.ArrayBuffer(initialState)
+    // Parallel index so deduplication lookup is O(1) instead of O(S) per call
+    // (and O(S^2) overall across the whole LR table construction).
+    val stateIndex = mutable.HashMap(initialState -> 0)
     val table = mutable.Map.empty[(state: Int, stepSymbol: Symbol), ParseAction]
 
     def addToTable(symbol: Symbol, action: ParseAction): Unit =
@@ -121,11 +122,13 @@ private[parser] object ParseTable:
       for stepSymbol <- currState.possibleSteps do
         val newState = currState.nextState(stepSymbol, productions, firstSet)
 
-        states.indexOf(newState) match
-          case -1 =>
-            addToTable(stepSymbol, Shift(states.length))
+        stateIndex.get(newState) match
+          case None =>
+            val newId = states.length
+            addToTable(stepSymbol, Shift(newId))
             states += newState
-          case stateId =>
+            stateIndex(newState) = newId
+          case Some(stateId) =>
             addToTable(stepSymbol, Shift(stateId))
 
       currStateId += 1

--- a/src/alpaca/internal/parser/ParseTable.scala
+++ b/src/alpaca/internal/parser/ParseTable.scala
@@ -120,14 +120,14 @@ private[parser] object ParseTable:
       for stepSymbol <- currState.possibleSteps do
         val newState = currState.nextState(stepSymbol, productions, firstSet)
 
-        stateIndex.get(newState) match
-          case None =>
+        val stateId = stateIndex.getOrElseUpdate(
+          newState, {
             val newId = states.length
-            addToTable(stepSymbol, Shift(newId))
             states += newState
-            stateIndex(newState) = newId
-          case Some(stateId) =>
-            addToTable(stepSymbol, Shift(stateId))
+            newId
+          },
+        )
+        addToTable(stepSymbol, Shift(stateId))
 
       currStateId += 1
 

--- a/src/alpaca/internal/parser/ParseTable.scala
+++ b/src/alpaca/internal/parser/ParseTable.scala
@@ -80,8 +80,6 @@ private[parser] object ParseTable:
       firstSet,
     )
     val states = mutable.ArrayBuffer(initialState)
-    // Parallel index so deduplication lookup is O(1) instead of O(S) per call
-    // (and O(S^2) overall across the whole LR table construction).
     val stateIndex = mutable.HashMap(initialState -> 0)
     val table = mutable.Map.empty[(state: Int, stepSymbol: Symbol), ParseAction]
 

--- a/test/src/alpaca/internal/parser/ParseTableRuntimeTest.scala
+++ b/test/src/alpaca/internal/parser/ParseTableRuntimeTest.scala
@@ -37,7 +37,7 @@ final class ParseTableRuntimeTest extends AnyFunSuite with Matchers:
     val unknown = Terminal("<unknown>")
 
     val ex = intercept[AlgorithmError](table(0, unknown))
-    ex.getMessage should (include("Unexpected symbol") and include("Expected one of:"))
+    ex.getMessage should (include("Unexpected symbol").and(include("Expected one of:")))
   }
 
   test("toCsv headers start with State and include all grammar symbols seen in the table") {

--- a/test/src/alpaca/internal/parser/ParseTableRuntimeTest.scala
+++ b/test/src/alpaca/internal/parser/ParseTableRuntimeTest.scala
@@ -1,0 +1,57 @@
+package alpaca
+package internal.parser
+
+import alpaca.internal.parser.ParseAction.*
+import alpaca.internal.{AlgorithmError, DebugSettings, Log, NEL}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+final class ParseTableRuntimeTest extends AnyFunSuite with Matchers:
+  private given DebugSettings = DebugSettings.default
+  private given Log = new Log
+
+  private val emptyResolutions = ConflictResolutionTable(Map.empty)
+
+  // Grammar:
+  //   S' -> E
+  //   E  -> E + Num
+  //   E  -> Num
+  private val E = NonTerminal("E")
+  private val Num = Terminal("Num")
+  private val Plus = Terminal("+")
+
+  private val productions: List[Production] = List(
+    Production.NonEmpty(Symbol.Start, NEL(E)),
+    Production.NonEmpty(E, NEL(E, Plus, Num), "EAdd"),
+    Production.NonEmpty(E, NEL(Num), "ENum"),
+  )
+
+  test("builds a parse table for a simple LR(1) grammar") {
+    val table = ParseTable(productions, emptyResolutions)
+
+    table(0, Num) shouldBe a[Shift]
+  }
+
+  test("apply raises AlgorithmError when no action exists for (state, symbol)") {
+    val table = ParseTable(productions, emptyResolutions)
+    val unknown = Terminal("<unknown>")
+
+    val ex = intercept[AlgorithmError](table(0, unknown))
+    ex.getMessage should (include("Unexpected symbol") and include("Expected one of:"))
+  }
+
+  test("toCsv headers start with State and include all grammar symbols seen in the table") {
+    val csv = ParseTable(productions, emptyResolutions).toCsv
+
+    csv.headers.head should include("State")
+    val headerNames = csv.headers.map(_.toString)
+    headerNames should contain(Num.name)
+    headerNames should contain(Plus.name)
+  }
+
+  test("Showable renders a non-empty textual representation with multiple rows") {
+    val rendered = ParseTable(productions, emptyResolutions).show
+
+    rendered should include("State")
+    rendered.linesIterator.size should be > 1
+  }


### PR DESCRIPTION
Addresses item **#9** (compile-time quadratic state dedup) from #371.

## Summary
- Replace `states.indexOf(newState)` — a linear scan through every existing state, called once per `(state × step)` pair and therefore O(S²) over the whole LR table build — with a parallel `mutable.HashMap[State, Int]` keyed by state. Lookup/insert is now O(1) average.
- Switch the state buffer from `ListBuffer` to `ArrayBuffer` for O(1) indexed access (it's used positionally via `states(currStateId)`).

## Test plan
- [ ] Full test suite passes (`./mill test`)
- [ ] No change in generated parse tables for existing grammars

🤖 Generated with [Claude Code](https://claude.com/claude-code)