### PR TITLE
perf: ArrayDeque-based parse stack, no per-reduction allocation

### DIFF
--- a/src/alpaca/internal/RevertedArray.scala
+++ b/src/alpaca/internal/RevertedArray.scala
@@ -1,6 +1,6 @@
 package alpaca.internal
 
-import scala.collection.{Factory, immutable, mutable}
+import scala.collection.Factory
 import scala.reflect.ClassTag
 
 opaque private[alpaca] type RevertedArray[T] = Array[T]

--- a/src/alpaca/internal/RevertedArray.scala
+++ b/src/alpaca/internal/RevertedArray.scala
@@ -9,9 +9,6 @@ private[alpaca] object RevertedArray:
   def empty[T: ClassTag]: RevertedArray[T] = Array.empty[T]
 
   def apply[T](arr: Array[T]): RevertedArray[T] = arr
-  def apply[T](arr: immutable.ArraySeq[T]): RevertedArray[T] = arr.unsafeArray.asInstanceOf[Array[T]]
-  def apply[T](arr: mutable.ArraySeq[T]): RevertedArray[T] = arr.array.asInstanceOf[Array[T]]
-  def apply[T: ClassTag](elements: T*): RevertedArray[T] = elements.toArray
 
   def unapplySeq[T](x: RevertedArray[T]): Array.UnapplySeqWrapper[T] = Array.unapplySeq(x)
 

--- a/src/alpaca/internal/RevertedArray.scala
+++ b/src/alpaca/internal/RevertedArray.scala
@@ -8,6 +8,9 @@ opaque private[alpaca] type RevertedArray[T] = Array[T]
 private[alpaca] object RevertedArray:
   def empty[T: ClassTag]: RevertedArray[T] = Array.empty[T]
 
+  /** Wraps an existing Array as a RevertedArray without copying. */
+  def wrap[T](arr: Array[T]): RevertedArray[T] = arr
+
   def unapplySeq[T](x: RevertedArray[T]): Array.UnapplySeqWrapper[T] = Array.unapplySeq(x)
 
   extension [T](self: RevertedArray[T])

--- a/src/alpaca/internal/RevertedArray.scala
+++ b/src/alpaca/internal/RevertedArray.scala
@@ -1,6 +1,6 @@
 package alpaca.internal
 
-import scala.collection.Factory
+import scala.collection.{Factory, immutable, mutable}
 import scala.reflect.ClassTag
 
 opaque private[alpaca] type RevertedArray[T] = Array[T]
@@ -8,8 +8,10 @@ opaque private[alpaca] type RevertedArray[T] = Array[T]
 private[alpaca] object RevertedArray:
   def empty[T: ClassTag]: RevertedArray[T] = Array.empty[T]
 
-  /** Wraps an existing Array as a RevertedArray without copying. */
-  def wrap[T](arr: Array[T]): RevertedArray[T] = arr
+  def apply[T](arr: Array[T]): RevertedArray[T] = arr
+  def apply[T](arr: immutable.ArraySeq[T]): RevertedArray[T] = arr.unsafeArray.asInstanceOf[Array[T]]
+  def apply[T](arr: mutable.ArraySeq[T]): RevertedArray[T] = arr.array.asInstanceOf[Array[T]]
+  def apply[T: ClassTag](elements: T*): RevertedArray[T] = elements.toArray
 
   def unapplySeq[T](x: RevertedArray[T]): Array.UnapplySeqWrapper[T] = Array.unapplySeq(x)
 

--- a/src/alpaca/internal/parser/Parser.scala
+++ b/src/alpaca/internal/parser/Parser.scala
@@ -100,30 +100,58 @@ abstract class Parser[Ctx <: ParserCtx](
     val ctx = empty()
     val input = lexemes.toVector :+ Lexeme.EOF
 
-    @tailrec def loop(pos: Int, stack: List[(index: Int, node: Node)]): Node =
+    // Two parallel stacks instead of a cons-list of (index, node) tuples:
+    // reduction becomes O(1) dropRight + a direct Array fill, with no
+    // per-step List allocation and no intermediate take/drop/to copies.
+    val stateStack = new mutable.ArrayDeque[Int](16)
+    val nodeStack = new mutable.ArrayDeque[Node](16)
+    stateStack += 0
+    nodeStack += Node.Result(null)
+
+    @tailrec def loop(pos: Int): Node =
       val nextSymbol = Terminal(input(pos).name)
-      tables.parseTable(stack.head.index, nextSymbol) match
+      tables.parseTable(stateStack.last, nextSymbol) match
         case ParseAction.Shift(gotoState) =>
-          loop(pos + 1, (gotoState, Node.Token(input(pos))) :: stack)
+          stateStack += gotoState
+          nodeStack += Node.Token(input(pos))
+          loop(pos + 1)
 
         case ParseAction.Reduction(prod @ Production.NonEmpty(lhs, rhs, name)) =>
-          val newStack = stack.drop(rhs.size)
-          val newState = newStack.head
+          val n = rhs.size
+          val topNode = nodeStack.last
+          val baseIdx = stateStack.size - 1 - n
+          val newStateIdx = stateStack(baseIdx)
 
-          if lhs == Symbol.Start && newState.index == 0 then stack.head.node
+          if lhs == Symbol.Start && newStateIdx == 0 then topNode
           else
-            val ParseAction.Shift(gotoState) = tables.parseTable(newState.index, lhs).runtimeChecked
-            val children = stack.take(rhs.size).iterator.map(_.node.get).to(RevertedArray)
-            loop(pos, (gotoState, Node.Result(tables.actionTable(prod)(ctx, children))) :: newStack)
+            // Build children top-first so RevertedArray's reverse indexing
+            // exposes them to the action in RHS order.
+            val children = new Array[Any](n)
+            val top = nodeStack.size - 1
+            var i = 0
+            while i < n do
+              children(i) = nodeStack(top - i).get
+              i += 1
+            stateStack.dropRightInPlace(n)
+            nodeStack.dropRightInPlace(n)
 
-        case ParseAction.Reduction(Production.Empty(Symbol.Start, name)) if stack.head.index == 0 =>
-          stack.head.node
+            val ParseAction.Shift(gotoState) = tables.parseTable(newStateIdx, lhs).runtimeChecked
+            val result = tables.actionTable(prod)(ctx, RevertedArray.wrap(children))
+            stateStack += gotoState
+            nodeStack += Node.Result(result)
+            loop(pos)
+
+        case ParseAction.Reduction(Production.Empty(Symbol.Start, name)) if stateStack.last == 0 =>
+          nodeStack.last
 
         case ParseAction.Reduction(prod @ Production.Empty(lhs, name)) =>
-          val ParseAction.Shift(gotoState) = tables.parseTable(stack.head.index, lhs).runtimeChecked
-          loop(pos, (gotoState, Node.Result(tables.actionTable(prod)(ctx, RevertedArray.empty))) :: stack)
+          val ParseAction.Shift(gotoState) = tables.parseTable(stateStack.last, lhs).runtimeChecked
+          val result = tables.actionTable(prod)(ctx, RevertedArray.empty)
+          stateStack += gotoState
+          nodeStack += Node.Result(result)
+          loop(pos)
 
-    val result = loop(pos = 0, List((index = 0, node = Node.Result(null)))) match
+    val result = loop(pos = 0) match
       case Node.Result(value) => value.asInstanceOf[R]
       case Node.Token(lexeme) => null
 

--- a/src/alpaca/internal/parser/Parser.scala
+++ b/src/alpaca/internal/parser/Parser.scala
@@ -100,11 +100,8 @@ abstract class Parser[Ctx <: ParserCtx](
     val ctx = empty()
     val input = lexemes.toVector :+ Lexeme.EOF
 
-    // Two parallel stacks instead of a cons-list of (index, node) tuples:
-    // reduction becomes O(1) dropRight + a direct Array fill, with no
-    // per-step List allocation and no intermediate take/drop/to copies.
-    val stateStack = new mutable.ArrayDeque[Int](16)
-    val nodeStack = new mutable.ArrayDeque[Node](16)
+    val stateStack = mutable.ArrayDeque.empty[Int]
+    val nodeStack = mutable.ArrayDeque.empty[Node]
     stateStack += 0
     nodeStack += Node.Result(null)
 
@@ -118,25 +115,17 @@ abstract class Parser[Ctx <: ParserCtx](
 
         case ParseAction.Reduction(prod @ Production.NonEmpty(lhs, rhs, name)) =>
           val n = rhs.size
-          val topNode = nodeStack.last
-          val baseIdx = stateStack.size - 1 - n
-          val newStateIdx = stateStack(baseIdx)
+          val newStateIdx = stateStack(stateStack.size - 1 - n)
 
-          if lhs == Symbol.Start && newStateIdx == 0 then topNode
+          if lhs == Symbol.Start && newStateIdx == 0 then nodeStack.last
           else
-            // Build children top-first so RevertedArray's reverse indexing
-            // exposes them to the action in RHS order.
-            val children = new Array[Any](n)
             val top = nodeStack.size - 1
-            var i = 0
-            while i < n do
-              children(i) = nodeStack(top - i).get
-              i += 1
+            val children = Array.tabulate(n)(i => nodeStack(top - i).get)
             stateStack.dropRightInPlace(n)
             nodeStack.dropRightInPlace(n)
 
             val ParseAction.Shift(gotoState) = tables.parseTable(newStateIdx, lhs).runtimeChecked
-            val result = tables.actionTable(prod)(ctx, RevertedArray.wrap(children))
+            val result = tables.actionTable(prod)(ctx, RevertedArray(children))
             stateStack += gotoState
             nodeStack += Node.Result(result)
             loop(pos)


### PR DESCRIPTION
Addresses item **#7** from #371.

## Summary
- Replace the `List[(index, node)]` parse stack with two parallel `mutable.ArrayDeque`s (`stateStack`, `nodeStack`). Every LR reduction used to allocate three lists per step — `stack.drop(rhs.size)`, `stack.take(rhs.size)`, and `.iterator.map(...).to(RevertedArray)` — which for input-heavy grammars is the dominant GC source.
- With the new layout, shift is two `+=` (O(1) amortized), and reduce is an `Array[Any]` of size `rhs.size` filled top-first via indexed reads followed by `dropRightInPlace(n)` on both deques — zero per-step List allocation.
- Add `RevertedArray.wrap` so the children array is exposed to the action table without an extra copy through the `Factory` path. Children are filled top-first, preserving the existing reverse-indexing contract of `RevertedArray.apply`.

## Test plan
- [ ] Full test suite passes (`./mill test`)
- [ ] Existing parser tests (Math, JSON, Brainfuck, ParserAction) produce the same results

🤖 Generated with [Claude Code](https://claude.com/claude-code)