### PR TITLE
perf(LazyReader): single-pass String build in subSequence

### DIFF
--- a/src/alpaca/internal/BetterArray.scala
+++ b/src/alpaca/internal/BetterArray.scala
@@ -1,0 +1,16 @@
+package alpaca.internal
+
+import scala.reflect.ClassTag
+
+extension (dummy: Array.type) inline private[internal] def better: BetterArray.type = BetterArray
+
+private[internal] object BetterArray:
+  inline def tabulate[T: ClassTag](n: Int)(inline f: Int => T): Array[T] =
+    if n <= 0 then Array.empty[T]
+    else
+      val array = new Array[T](n)
+      var i = 0
+      while i < n do
+        array(i) = f(i)
+        i += 1
+      array

--- a/src/alpaca/internal/lexer/LazyReader.scala
+++ b/src/alpaca/internal/lexer/LazyReader.scala
@@ -53,7 +53,14 @@ final class LazyReader(private val reader: Reader, private var size: Long) exten
    */
   def subSequence(start: Int, end: Int): CharSequence =
     ensure(end - 1 + offset)
-    buffer.slice(start + offset, end + offset).mkString
+    val len = end - start
+    val out = new Array[Char](len)
+    val base = start + offset
+    var i = 0
+    while i < len do
+      out(i) = buffer(base + i)
+      i += 1
+    new String(out)
 
   /**
    * Skips the first count characters.

--- a/src/alpaca/internal/lexer/LazyReader.scala
+++ b/src/alpaca/internal/lexer/LazyReader.scala
@@ -56,11 +56,7 @@ final class LazyReader(private val reader: Reader, private var size: Long) exten
     val len = end - start
     require(len >= 0, s"Invalid subsequence range: start=$start, end=$end")
     val base = start + offset
-    val out = new Array[Char](len)
-    var i = 0
-    while i < len do
-      out(i) = buffer(base + i)
-      i += 1
+    val out = Array.better.tabulate(len)(i => buffer(base + i))
     new String(out)
 
   /**

--- a/src/alpaca/internal/lexer/LazyReader.scala
+++ b/src/alpaca/internal/lexer/LazyReader.scala
@@ -56,7 +56,11 @@ final class LazyReader(private val reader: Reader, private var size: Long) exten
     val len = end - start
     require(len >= 0, s"Invalid subsequence range: start=$start, end=$end")
     val base = start + offset
-    val out = Array.better.tabulate(len)(i => buffer(base + i))
+    val out = new Array[Char](len)
+    var i = 0
+    while i < len do
+      out(i) = buffer(base + i)
+      i += 1
     new String(out)
 
   /**

--- a/src/alpaca/internal/lexer/LazyReader.scala
+++ b/src/alpaca/internal/lexer/LazyReader.scala
@@ -16,7 +16,7 @@ import scala.collection.mutable
  * can efficiently skip over processed characters.
  *
  * @param reader the underlying Reader to read from
- * @param size the total size of the input (if known)
+ * @param size   the total size of the input (if known)
  */
 //todo: use Ox
 final class LazyReader(private val reader: Reader, private var size: Long) extends CharSequence, Closeable:
@@ -54,12 +54,9 @@ final class LazyReader(private val reader: Reader, private var size: Long) exten
   def subSequence(start: Int, end: Int): CharSequence =
     ensure(end - 1 + offset)
     val len = end - start
-    val out = new Array[Char](len)
+    require(len >= 0, s"Invalid subsequence range: start=$start, end=$end")
     val base = start + offset
-    var i = 0
-    while i < len do
-      out(i) = buffer(base + i)
-      i += 1
+    val out = Array.tabulate(len)(i => buffer(base + i))
     new String(out)
 
   /**

--- a/src/alpaca/internal/lexer/LazyReader.scala
+++ b/src/alpaca/internal/lexer/LazyReader.scala
@@ -56,7 +56,7 @@ final class LazyReader(private val reader: Reader, private var size: Long) exten
     val len = end - start
     require(len >= 0, s"Invalid subsequence range: start=$start, end=$end")
     val base = start + offset
-    val out = Array.tabulate(len)(i => buffer(base + i))
+    val out = Array.better.tabulate(len)(i => buffer(base + i))
     new String(out)
 
   /**

--- a/src/alpaca/internal/parser/Parser.scala
+++ b/src/alpaca/internal/parser/Parser.scala
@@ -120,7 +120,7 @@ abstract class Parser[Ctx <: ParserCtx](
           if lhs == Symbol.Start && newStateIdx == 0 then nodeStack.last
           else
             val top = nodeStack.size - 1
-            val children = Array.tabulate(n)(i => nodeStack(top - i).get)
+            val children = Array.better.tabulate(n)(i => nodeStack(top - i).get)
             stateStack.dropRightInPlace(n)
             nodeStack.dropRightInPlace(n)
 


### PR DESCRIPTION
## Summary
- `LazyReader.subSequence` allocated an intermediate `ArrayDeque` (from `buffer.slice`) and then a `StringBuilder` (from `mkString`) on every regex-engine probe.
- Replaced with a single `Array[Char]` copy + `new String(out)` — one allocation instead of two.

Addresses item 4 in #371.

## Test plan
- [x] `./mill compile`
- [x] `./mill test`
- [x] `./mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll`

🤖 Generated with [Claude Code](https://claude.com/claude-code)