### PR TITLE
perf(ParseTable): back rows with Array, not Map

### DIFF
--- a/src/alpaca/internal/internal.scala
+++ b/src/alpaca/internal/internal.scala
@@ -2,6 +2,7 @@ package alpaca
 package internal
 
 import scala.NamedTuple.{AnyNamedTuple, NamedTuple}
+import scala.collection.mutable
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
 /**
@@ -237,6 +238,28 @@ private[internal] def fieldsTpeFrom(using quotes: Quotes)(refn: Seq[(label: Stri
             )
         .toList,
     )
+
+private def avoidTooLargeMethod[A: Type, To: Type, B <: mutable.Builder[A, To]: Type](
+  builder: Expr[B],
+  elements: Iterable[Expr[A]],
+  empty: Expr[To],
+)(using quotes: Quotes,
+) =
+  import quotes.reflect.*
+  if elements.isEmpty then empty
+  else
+    ValDef
+      .let(Symbol.spliceOwner, "builder", builder.asTerm): ref =>
+        val builder = ref.asExprOf[B]
+        val additions = elements
+          .map: entry =>
+            '{
+              def local(): Unit = $builder += $entry
+              local()
+            }.asTerm
+          .toList
+        Block(additions, '{ $builder.result() }.asTerm)
+      .asExprOf[To]
 // $COVERAGE-ON$
 
 /**

--- a/src/alpaca/internal/internal.scala
+++ b/src/alpaca/internal/internal.scala
@@ -239,12 +239,12 @@ private[internal] def fieldsTpeFrom(using quotes: Quotes)(refn: Seq[(label: Stri
         .toList,
     )
 
-private def avoidTooLargeMethod[A: Type, To: Type, B <: mutable.Builder[A, To]: Type](
+private[alpaca] def avoidTooLargeMethod[A: Type, To: Type, B <: mutable.Builder[A, To]: Type](
   builder: Expr[B],
   elements: Iterable[Expr[A]],
   empty: Expr[To],
 )(using quotes: Quotes,
-) =
+): Expr[To] =
   import quotes.reflect.*
   if elements.isEmpty then empty
   else

--- a/src/alpaca/internal/parser/ParseTable.scala
+++ b/src/alpaca/internal/parser/ParseTable.scala
@@ -178,30 +178,29 @@ private[parser] object ParseTable:
     def apply(entries: ParseTable)(using quotes: Quotes): Expr[ParseTable] =
       import quotes.reflect.*
 
-      type MapBuilderTpe[K, V] = mutable.Builder[(K, V), Map[K, V]]
-
-      def mapBuilder[K: Type, V: Type](entries: List[Expr[(K, V)]]): Expr[Map[K, V]] =
-        val sym = Symbol.newVal(
-          Symbol.spliceOwner,
-          Symbol.freshName("rowBuilder"),
-          TypeRepr.of[MapBuilderTpe[K, V]],
-          Flags.Synthetic,
-          Symbol.noSymbol,
-        )
-        val valDef = ValDef(sym, Some('{ Map.newBuilder: MapBuilderTpe[K, V] }.asTerm))
-        val builder = Ref(sym).asExprOf[MapBuilderTpe[K, V]]
-
-        val additions = entries.map: entry =>
-          '{
-            def avoidTooLargeMethod(): Unit = $builder += $entry
-            avoidTooLargeMethod()
-          }.asTerm
-
-        Block(valDef :: additions, '{ $builder.result() }.asTerm).asExprOf[Map[K, V]]
+      type RowBuilder = mutable.Builder[(parser.Symbol, ParseAction), Map[parser.Symbol, ParseAction]]
 
       def rowExpr(row: Map[parser.Symbol, ParseAction]): Expr[Map[parser.Symbol, ParseAction]] =
         if row.isEmpty then '{ Map.empty[parser.Symbol, ParseAction] }
-        else mapBuilder[parser.Symbol, ParseAction](row.toList.map(Expr(_)))
+        else
+          val sym = Symbol.newVal(
+            Symbol.spliceOwner,
+            Symbol.freshName("rowBuilder"),
+            TypeRepr.of[RowBuilder],
+            Flags.Synthetic,
+            Symbol.noSymbol,
+          )
+          val valDef = ValDef(sym, Some('{ Map.newBuilder: RowBuilder }.asTerm))
+          val builder = Ref(sym).asExprOf[RowBuilder]
+
+          val additions = row.toList.map: entry =>
+            '{
+              def avoidTooLargeMethod(): Unit = $builder += ${ Expr(entry) }
+              avoidTooLargeMethod()
+            }.asTerm
+
+          Block(valDef :: additions, '{ $builder.result() }.asTerm)
+            .asExprOf[Map[parser.Symbol, ParseAction]]
 
       val tableSym = Symbol.newVal(
         Symbol.spliceOwner,

--- a/src/alpaca/internal/parser/ParseTable.scala
+++ b/src/alpaca/internal/parser/ParseTable.scala
@@ -7,6 +7,7 @@ import alpaca.internal.parser.ParseAction.*
 import scala.annotation.tailrec
 import scala.collection.immutable.SortedSet
 import scala.collection.mutable
+import scala.util.boundary, boundary.break
 
 /**
  * An opaque type representing the LR parse table.
@@ -19,8 +20,10 @@ import scala.collection.mutable
 opaque private[parser] type ParseTable = Array[Map[Symbol, ParseAction]]
 
 private[parser] object ParseTable:
-  private[parser] def fromMap(m: Map[Int, Map[Symbol, ParseAction]]): ParseTable =
-    Array.tabulate(m.size)(i => m.getOrElse(i, Map.empty))
+  inline private[parser] def allocate(n: Int): Array[AnyRef] =
+    new Array[Map[Symbol, ParseAction]](n).asInstanceOf[Array[AnyRef]]
+
+  inline private[parser] def unsafeWrap(arr: Array[AnyRef]): ParseTable = arr.asInstanceOf[ParseTable]
 
   extension (table: ParseTable)
     /**
@@ -31,12 +34,11 @@ private[parser] object ParseTable:
      * @return the parse action to take
      * @throws AlgorithmError if no action is defined for this state/symbol combination
      */
-    def apply(state: Int, symbol: Symbol): ParseAction = table(state).getOrElse(
-      symbol, {
+    def apply(state: Int, symbol: Symbol): ParseAction = table(state).get(symbol) match
+      case Some(action) => action
+      case None =>
         val expected = table(state).keysIterator.map(_.name).to(SortedSet).mkString(", ")
         throw AlgorithmError(s"Unexpected symbol '${symbol.name}' in state $state. Expected one of: $expected")
-      },
-    )
 
     private def allSymbols: List[Symbol] =
       table.iterator.flatMap(_.keysIterator).distinct.toList
@@ -54,9 +56,11 @@ private[parser] object ParseTable:
       val symbols = table.allSymbols
 
       val headers = show"State" :: symbols.map(_.show)
-      val rows = table.indices.toList.map: i =>
-        val row = table(i)
-        show"$i" :: symbols.map(s => row.get(s).fold[Shown]("")(_.show))
+      val rows = table.indices
+        .map: i =>
+          val row = table(i)
+          show"$i" :: symbols.map(s => row.get(s).fold[Shown]("")(_.show))
+        .toList
 
       Csv(headers, rows)
 
@@ -85,14 +89,10 @@ private[parser] object ParseTable:
     )
     val states = mutable.ArrayBuffer(initialState)
     val stateIndex = mutable.HashMap(initialState -> 0)
-    val tableRows = mutable.ArrayBuffer.empty[mutable.HashMap[Symbol, ParseAction]]
-
-    def rowFor(stateId: Int): mutable.HashMap[Symbol, ParseAction] =
-      while tableRows.sizeIs <= stateId do tableRows += mutable.HashMap.empty
-      tableRows(stateId)
+    val tableRows = mutable.ArrayBuffer(mutable.HashMap.empty[Symbol, ParseAction])
 
     def addToTable(symbol: Symbol, action: ParseAction): Unit =
-      val row = rowFor(currStateId)
+      val row = tableRows(currStateId)
       row.get(symbol) match
         case None => row.update(symbol, action)
         case Some(existingAction) =>
@@ -111,11 +111,14 @@ private[parser] object ParseTable:
     @tailrec def toPath(stateId: Int, acc: List[Symbol]): List[Symbol] =
       if stateId == 0 then acc
       else
-        val (sourceStateId, symbol) = tableRows.iterator.zipWithIndex
-          .flatMap:
-            case (row, srcId) =>
-              row.collectFirst { case (sym, Shift(`stateId`)) => (srcId, sym) }
-          .next()
+        val predecessor = boundary[Option[(Int, Symbol)]]:
+          for srcId <- tableRows.indices do
+            tableRows(srcId).foreach:
+              case (sym, Shift(`stateId`)) => break(Some((srcId, sym)))
+              case _ =>
+          None
+        val (sourceStateId, symbol) =
+          predecessor.getOrElse(throw AlgorithmError(show"No predecessor state found for state $stateId"))
         if sourceStateId == stateId then
           logger.debug(show"Unable to trace back path for state, cycle detected near symbol: $symbol")
           symbol :: acc
@@ -123,7 +126,6 @@ private[parser] object ParseTable:
 
     while states.sizeIs > currStateId do
       val currState = states(currStateId)
-      rowFor(currStateId) // ensure row exists even for states with no entries
       logger.trace(show"processing state $currStateId")
 
       for item <- currState if item.isLastItem do addToTable(item.lookAhead, Reduction(item.production))
@@ -135,6 +137,7 @@ private[parser] object ParseTable:
           newState, {
             val newId = states.length
             states += newState
+            tableRows += mutable.HashMap.empty
             newId
           },
         )
@@ -142,7 +145,7 @@ private[parser] object ParseTable:
 
       currStateId += 1
 
-    Array.tabulate(tableRows.length)(tableRows(_).toMap)
+    Array.better.tabulate(tableRows.length)(tableRows(_).toMap)
 
   given Showable[ParseTable] = Showable: table =>
     val symbols = table.allSymbols
@@ -206,8 +209,21 @@ private[parser] object ParseTable:
         if row.isEmpty then '{ Map.empty[parser.Symbol, ParseAction] }
         else mapBuilder[parser.Symbol, ParseAction]("rowBuilder", row.toList.map(Expr(_)))
 
-      val outerEntries = entries.toList.zipWithIndex.map: (row, i) =>
-        '{ (${ Expr(i) }, ${ rowExpr(row) }) }
+      val tableSym = Symbol.newVal(
+        Symbol.spliceOwner,
+        Symbol.freshName("parseTable"),
+        TypeRepr.of[Array[AnyRef]],
+        Flags.Synthetic,
+        Symbol.noSymbol,
+      )
+      val tableValDef = ValDef(tableSym, Some('{ ParseTable.allocate(${ Expr(entries.length) }) }.asTerm))
+      val tableRef = Ref(tableSym).asExprOf[Array[AnyRef]]
 
-      '{ ParseTable.fromMap(${ mapBuilder[Int, Map[parser.Symbol, ParseAction]]("tableBuilder", outerEntries) }) }
+      val rowAssignments = entries.toList.zipWithIndex.map: (row, i) =>
+        '{
+          def avoidTooLargeMethod(): Unit = $tableRef(${ Expr(i) }) = ${ rowExpr(row) }
+          avoidTooLargeMethod()
+        }.asTerm
+
+      Block(tableValDef :: rowAssignments, '{ ParseTable.unsafeWrap($tableRef) }.asTerm).asExprOf[ParseTable]
 // $COVERAGE-ON$

--- a/src/alpaca/internal/parser/ParseTable.scala
+++ b/src/alpaca/internal/parser/ParseTable.scala
@@ -178,15 +178,15 @@ private[parser] object ParseTable:
       type Row = Map[parser.Symbol, ParseAction]
       type RowBuilder = mutable.Builder[(parser.Symbol, ParseAction), Row]
 
-      def rowExpr(row: Row): Expr[Row] = avoidToLargeMethod[(parser.Symbol, ParseAction), Row, RowBuilder](
+      def rowExpr(row: Row): Expr[Row] = avoidTooLargeMethod[(parser.Symbol, ParseAction), Row, RowBuilder](
         builder = '{ Map.newBuilder },
         elements = row.map(Expr(_)),
         empty = '{ Map.empty },
       )
 
-      avoidToLargeMethod[Row, Array[Row], mutable.ArrayBuilder[Row]](
+      avoidTooLargeMethod[Row, Array[Row], mutable.ArrayBuilder[Row]](
         builder = '{ mutable.ArrayBuilder.ofRef[Row].tap(_.sizeHint(${ Expr(entries.length) })) },
         elements = entries.map(rowExpr),
-        empty = '{ Array.empty },
+        empty = '{ Array.empty[Row] },
       )
 // $COVERAGE-ON$

--- a/src/alpaca/internal/parser/ParseTable.scala
+++ b/src/alpaca/internal/parser/ParseTable.scala
@@ -7,7 +7,8 @@ import alpaca.internal.parser.ParseAction.*
 import scala.annotation.tailrec
 import scala.collection.immutable.SortedSet
 import scala.collection.mutable
-import scala.util.boundary, boundary.break
+import scala.util.boundary
+import boundary.break
 
 /**
  * An opaque type representing the LR parse table.
@@ -20,10 +21,6 @@ import scala.util.boundary, boundary.break
 opaque private[parser] type ParseTable = Array[Map[Symbol, ParseAction]]
 
 private[parser] object ParseTable:
-  inline private[parser] def allocate(n: Int): Array[AnyRef] =
-    new Array[Map[Symbol, ParseAction]](n).asInstanceOf[Array[AnyRef]]
-
-  inline private[parser] def unsafeWrap(arr: Array[AnyRef]): ParseTable = arr.asInstanceOf[ParseTable]
 
   extension (table: ParseTable)
     /**
@@ -108,17 +105,17 @@ private[parser] object ParseTable:
                 case (red: Reduction, Shift(_)) => throw ShiftReduceConflict(symbol, red, path)
                 case (Shift(_), Shift(_)) => throw AlgorithmError("Shift-Shift conflict should never happen")
 
+    // noinspection ScalaUnreachableCode
     @tailrec def toPath(stateId: Int, acc: List[Symbol]): List[Symbol] =
       if stateId == 0 then acc
       else
-        val predecessor = boundary[Option[(Int, Symbol)]]:
+        val (sourceStateId, symbol) = boundary[(Int, Symbol)]:
           for srcId <- tableRows.indices do
             tableRows(srcId).foreach:
-              case (sym, Shift(`stateId`)) => break(Some((srcId, sym)))
+              case (sym, Shift(`stateId`)) => break((srcId, sym))
               case _ =>
-          None
-        val (sourceStateId, symbol) =
-          predecessor.getOrElse(throw AlgorithmError(show"No predecessor state found for state $stateId"))
+          throw AlgorithmError(show"No predecessor state found for state $stateId")
+
         if sourceStateId == stateId then
           logger.debug(show"Unable to trace back path for state, cycle detected near symbol: $symbol")
           symbol :: acc
@@ -183,13 +180,10 @@ private[parser] object ParseTable:
 
       type MapBuilderTpe[K, V] = mutable.Builder[(K, V), Map[K, V]]
 
-      def mapBuilder[K: Type, V: Type](
-        name: String,
-        entries: List[Expr[(K, V)]],
-      ): Expr[Map[K, V]] =
+      def mapBuilder[K: Type, V: Type](entries: List[Expr[(K, V)]]): Expr[Map[K, V]] =
         val sym = Symbol.newVal(
           Symbol.spliceOwner,
-          Symbol.freshName(name),
+          Symbol.freshName("rowBuilder"),
           TypeRepr.of[MapBuilderTpe[K, V]],
           Flags.Synthetic,
           Symbol.noSymbol,
@@ -207,17 +201,20 @@ private[parser] object ParseTable:
 
       def rowExpr(row: Map[parser.Symbol, ParseAction]): Expr[Map[parser.Symbol, ParseAction]] =
         if row.isEmpty then '{ Map.empty[parser.Symbol, ParseAction] }
-        else mapBuilder[parser.Symbol, ParseAction]("rowBuilder", row.toList.map(Expr(_)))
+        else mapBuilder[parser.Symbol, ParseAction](row.toList.map(Expr(_)))
 
       val tableSym = Symbol.newVal(
         Symbol.spliceOwner,
         Symbol.freshName("parseTable"),
-        TypeRepr.of[Array[AnyRef]],
+        TypeRepr.of[ParseTable],
         Flags.Synthetic,
         Symbol.noSymbol,
       )
-      val tableValDef = ValDef(tableSym, Some('{ ParseTable.allocate(${ Expr(entries.length) }) }.asTerm))
-      val tableRef = Ref(tableSym).asExprOf[Array[AnyRef]]
+      val tableValDef = ValDef(
+        tableSym,
+        Some('{ new Array[Map[parser.Symbol, ParseAction]](${ Expr(entries.length) }) }.asTerm),
+      )
+      val tableRef = Ref(tableSym).asExprOf[Array[Map[parser.Symbol, ParseAction]]]
 
       val rowAssignments = entries.toList.zipWithIndex.map: (row, i) =>
         '{
@@ -225,5 +222,5 @@ private[parser] object ParseTable:
           avoidTooLargeMethod()
         }.asTerm
 
-      Block(tableValDef :: rowAssignments, '{ ParseTable.unsafeWrap($tableRef) }.asTerm).asExprOf[ParseTable]
+      Block(tableValDef :: rowAssignments, '{ $tableRef: ParseTable }.asTerm).asExprOf[ParseTable]
 // $COVERAGE-ON$

--- a/src/alpaca/internal/parser/ParseTable.scala
+++ b/src/alpaca/internal/parser/ParseTable.scala
@@ -21,7 +21,6 @@ import boundary.break
 opaque private[parser] type ParseTable = Array[Map[Symbol, ParseAction]]
 
 private[parser] object ParseTable:
-
   extension (table: ParseTable)
     /**
      * Gets the parse action for a given state and symbol.
@@ -180,6 +179,13 @@ private[parser] object ParseTable:
 
       type RowBuilder = mutable.Builder[(parser.Symbol, ParseAction), Map[parser.Symbol, ParseAction]]
 
+      // Each statement is wrapped in its own local def to keep the enclosing
+      // method under the JVM's 64KB bytecode limit for large grammars.
+      def wrapped(body: Expr[Unit]): Term = '{
+        def avoidTooLargeMethod(): Unit = $body
+        avoidTooLargeMethod()
+      }.asTerm
+
       def rowExpr(row: Map[parser.Symbol, ParseAction]): Expr[Map[parser.Symbol, ParseAction]] =
         if row.isEmpty then '{ Map.empty[parser.Symbol, ParseAction] }
         else
@@ -194,10 +200,7 @@ private[parser] object ParseTable:
           val builder = Ref(sym).asExprOf[RowBuilder]
 
           val additions = row.toList.map: entry =>
-            '{
-              def avoidTooLargeMethod(): Unit = $builder += ${ Expr(entry) }
-              avoidTooLargeMethod()
-            }.asTerm
+            wrapped('{ $builder += ${ Expr(entry) } })
 
           Block(valDef :: additions, '{ $builder.result() }.asTerm)
             .asExprOf[Map[parser.Symbol, ParseAction]]
@@ -205,21 +208,18 @@ private[parser] object ParseTable:
       val tableSym = Symbol.newVal(
         Symbol.spliceOwner,
         Symbol.freshName("parseTable"),
-        TypeRepr.of[ParseTable],
+        TypeRepr.of[Array[AnyRef]],
         Flags.Synthetic,
         Symbol.noSymbol,
       )
       val tableValDef = ValDef(
         tableSym,
-        Some('{ new Array[Map[parser.Symbol, ParseAction]](${ Expr(entries.length) }) }.asTerm),
+        Some('{ new Array[Map[?, ?]](${ Expr(entries.length) }).asInstanceOf[Array[AnyRef]] }.asTerm),
       )
-      val tableRef = Ref(tableSym).asExprOf[Array[Map[parser.Symbol, ParseAction]]]
+      val tableRef = Ref(tableSym).asExprOf[Array[AnyRef]]
 
       val rowAssignments = entries.toList.zipWithIndex.map: (row, i) =>
-        '{
-          def avoidTooLargeMethod(): Unit = $tableRef(${ Expr(i) }) = ${ rowExpr(row) }
-          avoidTooLargeMethod()
-        }.asTerm
+        wrapped('{ $tableRef(${ Expr(i) }) = ${ rowExpr(row) } })
 
-      Block(tableValDef :: rowAssignments, '{ $tableRef: ParseTable }.asTerm).asExprOf[ParseTable]
+      Block(tableValDef :: rowAssignments, '{ $tableRef.asInstanceOf[ParseTable] }.asTerm).asExprOf[ParseTable]
 // $COVERAGE-ON$

--- a/src/alpaca/internal/parser/ParseTable.scala
+++ b/src/alpaca/internal/parser/ParseTable.scala
@@ -11,13 +11,17 @@ import scala.collection.mutable
 /**
  * An opaque type representing the LR parse table.
  *
- * The parse table is a nested map: state -> symbol -> action. This avoids
- * allocating a tuple key on every lookup and keeps the hash of the hot
- * `parseTable(state, symbol)` call to a single symbol hash.
+ * State IDs are dense consecutive integers starting at 0, so the table is
+ * stored as an array indexed by state, with each cell holding a symbol ->
+ * action map. Lookup is a single array index plus one symbol hash, with no
+ * boxing on the state key.
  */
-opaque private[parser] type ParseTable = Map[Int, Map[Symbol, ParseAction]]
+opaque private[parser] type ParseTable = Array[Map[Symbol, ParseAction]]
 
 private[parser] object ParseTable:
+  private[parser] def fromMap(m: Map[Int, Map[Symbol, ParseAction]]): ParseTable =
+    Array.tabulate(m.size)(i => m.getOrElse(i, Map.empty))
+
   extension (table: ParseTable)
     /**
      * Gets the parse action for a given state and symbol.
@@ -27,17 +31,15 @@ private[parser] object ParseTable:
      * @return the parse action to take
      * @throws AlgorithmError if no action is defined for this state/symbol combination
      */
-    def apply(state: Int, symbol: Symbol): ParseAction =
-      val row = table.getOrElse(state, Map.empty)
-      row.getOrElse(
-        symbol, {
-          val expected = row.keysIterator.map(_.name).to(SortedSet).mkString(", ")
-          throw AlgorithmError(s"Unexpected symbol '${symbol.name}' in state $state. Expected one of: $expected")
-        },
-      )
+    def apply(state: Int, symbol: Symbol): ParseAction = table(state).getOrElse(
+      symbol, {
+        val expected = table(state).keysIterator.map(_.name).to(SortedSet).mkString(", ")
+        throw AlgorithmError(s"Unexpected symbol '${symbol.name}' in state $state. Expected one of: $expected")
+      },
+    )
 
     private def allSymbols: List[Symbol] =
-      table.valuesIterator.flatMap(_.keysIterator).distinct.toList
+      table.iterator.flatMap(_.keysIterator).distinct.toList
 
     /**
      * Converts the parse table to CSV format for debugging.
@@ -50,10 +52,9 @@ private[parser] object ParseTable:
     // it shouldn't be eager
     def toCsv(using Log): Csv =
       val symbols = table.allSymbols
-      val states = table.keysIterator.toList.sorted
 
       val headers = show"State" :: symbols.map(_.show)
-      val rows = states.map: i =>
+      val rows = table.indices.toList.map: i =>
         val row = table(i)
         show"$i" :: symbols.map(s => row.get(s).fold[Shown]("")(_.show))
 
@@ -84,10 +85,11 @@ private[parser] object ParseTable:
     )
     val states = mutable.ArrayBuffer(initialState)
     val stateIndex = mutable.HashMap(initialState -> 0)
-    val table = mutable.HashMap.empty[Int, mutable.HashMap[Symbol, ParseAction]]
+    val tableRows = mutable.ArrayBuffer.empty[mutable.HashMap[Symbol, ParseAction]]
 
     def rowFor(stateId: Int): mutable.HashMap[Symbol, ParseAction] =
-      table.getOrElseUpdate(stateId, mutable.HashMap.empty)
+      while tableRows.sizeIs <= stateId do tableRows += mutable.HashMap.empty
+      tableRows(stateId)
 
     def addToTable(symbol: Symbol, action: ParseAction): Unit =
       val row = rowFor(currStateId)
@@ -109,10 +111,10 @@ private[parser] object ParseTable:
     @tailrec def toPath(stateId: Int, acc: List[Symbol]): List[Symbol] =
       if stateId == 0 then acc
       else
-        val (sourceStateId, symbol) = table.iterator
-          .flatMap { case (srcId, row) =>
-            row.collectFirst { case (sym, Shift(`stateId`)) => (srcId, sym) }
-          }
+        val (sourceStateId, symbol) = tableRows.iterator.zipWithIndex
+          .flatMap:
+            case (row, srcId) =>
+              row.collectFirst { case (sym, Shift(`stateId`)) => (srcId, sym) }
           .next()
         if sourceStateId == stateId then
           logger.debug(show"Unable to trace back path for state, cycle detected near symbol: $symbol")
@@ -140,11 +142,10 @@ private[parser] object ParseTable:
 
       currStateId += 1
 
-    table.iterator.map { case (i, row) => (i, row.toMap) }.toMap
+    Array.tabulate(tableRows.length)(tableRows(_).toMap)
 
   given Showable[ParseTable] = Showable: table =>
     val symbols = table.allSymbols
-    val states = table.keysIterator.toList.sorted
 
     def centerText(text: String, width: Int = 10): String =
       if text.length >= width then text
@@ -161,7 +162,7 @@ private[parser] object ParseTable:
       result.append(centerText(s.show))
       result.append("|")
 
-    for i <- states do
+    for i <- table.indices do
       val row = table(i)
       result.append('\n')
       result.append(centerText(i.toString))
@@ -177,52 +178,36 @@ private[parser] object ParseTable:
     def apply(entries: ParseTable)(using quotes: Quotes): Expr[ParseTable] =
       import quotes.reflect.*
 
-      type RowBuilderTpe = mutable.Builder[(parser.Symbol, ParseAction), Map[parser.Symbol, ParseAction]]
-      type OuterBuilderTpe = mutable.Builder[
-        (Int, Map[parser.Symbol, ParseAction]),
-        Map[Int, Map[parser.Symbol, ParseAction]],
-      ]
+      type MapBuilderTpe[K, V] = mutable.Builder[(K, V), Map[K, V]]
+
+      def mapBuilder[K: Type, V: Type](
+        name: String,
+        entries: List[Expr[(K, V)]],
+      ): Expr[Map[K, V]] =
+        val sym = Symbol.newVal(
+          Symbol.spliceOwner,
+          Symbol.freshName(name),
+          TypeRepr.of[MapBuilderTpe[K, V]],
+          Flags.Synthetic,
+          Symbol.noSymbol,
+        )
+        val valDef = ValDef(sym, Some('{ Map.newBuilder: MapBuilderTpe[K, V] }.asTerm))
+        val builder = Ref(sym).asExprOf[MapBuilderTpe[K, V]]
+
+        val additions = entries.map: entry =>
+          '{
+            def avoidTooLargeMethod(): Unit = $builder += $entry
+            avoidTooLargeMethod()
+          }.asTerm
+
+        Block(valDef :: additions, '{ $builder.result() }.asTerm).asExprOf[Map[K, V]]
 
       def rowExpr(row: Map[parser.Symbol, ParseAction]): Expr[Map[parser.Symbol, ParseAction]] =
         if row.isEmpty then '{ Map.empty[parser.Symbol, ParseAction] }
-        else
-          val rowSym = Symbol.newVal(
-            Symbol.spliceOwner,
-            Symbol.freshName("rowBuilder"),
-            TypeRepr.of[RowBuilderTpe],
-            Flags.Synthetic,
-            Symbol.noSymbol,
-          )
-          val rowValDef = ValDef(rowSym, Some('{ Map.newBuilder: RowBuilderTpe }.asTerm))
-          val rowBuilder = Ref(rowSym).asExprOf[RowBuilderTpe]
+        else mapBuilder[parser.Symbol, ParseAction]("rowBuilder", row.toList.map(Expr(_)))
 
-          val additions = row.toList.map: entry =>
-            '{
-              def avoidTooLargeMethod(): Unit = $rowBuilder += ${ Expr(entry) }
-              avoidTooLargeMethod()
-            }.asTerm
+      val outerEntries = entries.toList.zipWithIndex.map: (row, i) =>
+        '{ (${ Expr(i) }, ${ rowExpr(row) }) }
 
-          Block(rowValDef :: additions, '{ $rowBuilder.result() }.asTerm)
-            .asExprOf[Map[parser.Symbol, ParseAction]]
-
-      val outerSym = Symbol.newVal(
-        Symbol.spliceOwner,
-        Symbol.freshName("tableBuilder"),
-        TypeRepr.of[OuterBuilderTpe],
-        Flags.Synthetic,
-        Symbol.noSymbol,
-      )
-      val outerValDef = ValDef(outerSym, Some('{ Map.newBuilder: OuterBuilderTpe }.asTerm))
-      val outerBuilder = Ref(outerSym).asExprOf[OuterBuilderTpe]
-
-      val rowAdditions = entries.toList.map: (stateId, row) =>
-        '{
-          def avoidTooLargeMethod(): Unit =
-            $outerBuilder += ((${ Expr(stateId) }, ${ rowExpr(row) }))
-          avoidTooLargeMethod()
-        }.asTerm
-
-      val result = '{ $outerBuilder.result() }.asTerm
-
-      Block(outerValDef :: rowAdditions, result).asExprOf[ParseTable]
+      '{ ParseTable.fromMap(${ mapBuilder[Int, Map[parser.Symbol, ParseAction]]("tableBuilder", outerEntries) }) }
 // $COVERAGE-ON$

--- a/src/alpaca/internal/parser/ParseTable.scala
+++ b/src/alpaca/internal/parser/ParseTable.scala
@@ -11,10 +11,11 @@ import scala.collection.mutable
 /**
  * An opaque type representing the LR parse table.
  *
- * The parse table maps from (state, symbol) pairs to parse actions.
- * This table is generated at compile time from the grammar.
+ * The parse table is a nested map: state -> symbol -> action. This avoids
+ * allocating a tuple key on every lookup and keeps the hash of the hot
+ * `parseTable(state, symbol)` call to a single symbol hash.
  */
-opaque private[parser] type ParseTable = Map[(state: Int, stepSymbol: Symbol), ParseAction]
+opaque private[parser] type ParseTable = Map[Int, Map[Symbol, ParseAction]]
 
 private[parser] object ParseTable:
   extension (table: ParseTable)
@@ -27,16 +28,16 @@ private[parser] object ParseTable:
      * @throws AlgorithmError if no action is defined for this state/symbol combination
      */
     def apply(state: Int, symbol: Symbol): ParseAction =
-      try table((state, symbol))
-      catch
-        case _: NoSuchElementException =>
-          val expected = table.keysIterator
-            .collect:
-              case (`state`, sym) => sym.name
-            .to(SortedSet)
-            .mkString(", ")
-
+      val row = table.getOrElse(state, Map.empty)
+      row.getOrElse(
+        symbol, {
+          val expected = row.keysIterator.map(_.name).to(SortedSet).mkString(", ")
           throw AlgorithmError(s"Unexpected symbol '${symbol.name}' in state $state. Expected one of: $expected")
+        },
+      )
+
+    private def allSymbols: List[Symbol] =
+      table.valuesIterator.flatMap(_.keysIterator).distinct.toList
 
     /**
      * Converts the parse table to CSV format for debugging.
@@ -48,11 +49,13 @@ private[parser] object ParseTable:
      */
     // it shouldn't be eager
     def toCsv(using Log): Csv =
-      val symbols = table.keysIterator.map(_.stepSymbol).distinct.toList
-      val states = table.keysIterator.map(_.state).distinct.toList.sorted // todo: SortedSet?
+      val symbols = table.allSymbols
+      val states = table.keysIterator.toList.sorted
 
       val headers = show"State" :: symbols.map(_.show)
-      val rows = states.map(i => show"$i" :: symbols.map(s => table.get((i, s)).fold[Shown]("")(_.show)))
+      val rows = states.map: i =>
+        val row = table(i)
+        show"$i" :: symbols.map(s => row.get(s).fold[Shown]("")(_.show))
 
       Csv(headers, rows)
 
@@ -81,16 +84,20 @@ private[parser] object ParseTable:
     )
     val states = mutable.ArrayBuffer(initialState)
     val stateIndex = mutable.HashMap(initialState -> 0)
-    val table = mutable.Map.empty[(state: Int, stepSymbol: Symbol), ParseAction]
+    val table = mutable.HashMap.empty[Int, mutable.HashMap[Symbol, ParseAction]]
+
+    def rowFor(stateId: Int): mutable.HashMap[Symbol, ParseAction] =
+      table.getOrElseUpdate(stateId, mutable.HashMap.empty)
 
     def addToTable(symbol: Symbol, action: ParseAction): Unit =
-      table.get((currStateId, symbol)) match
-        case None => table.update((currStateId, symbol), action)
+      val row = rowFor(currStateId)
+      row.get(symbol) match
+        case None => row.update(symbol, action)
         case Some(existingAction) =>
           conflictResolutionTable.get(existingAction, action)(symbol) match
             case Some(action) =>
               logger.trace(show"Conflict resolved: $action")
-              table.update((currStateId, symbol), action)
+              row.update(symbol, action)
             case None =>
               val path = toPath(currStateId, List(symbol))
               (existingAction, action) match
@@ -102,10 +109,11 @@ private[parser] object ParseTable:
     @tailrec def toPath(stateId: Int, acc: List[Symbol]): List[Symbol] =
       if stateId == 0 then acc
       else
-        val (sourceStateId, symbol) = table
-          .collectFirst:
-            case (key, Shift(`stateId`)) => key
-          .get
+        val (sourceStateId, symbol) = table.iterator
+          .flatMap { case (srcId, row) =>
+            row.collectFirst { case (sym, Shift(`stateId`)) => (srcId, sym) }
+          }
+          .next()
         if sourceStateId == stateId then
           logger.debug(show"Unable to trace back path for state, cycle detected near symbol: $symbol")
           symbol :: acc
@@ -113,6 +121,7 @@ private[parser] object ParseTable:
 
     while states.sizeIs > currStateId do
       val currState = states(currStateId)
+      rowFor(currStateId) // ensure row exists even for states with no entries
       logger.trace(show"processing state $currStateId")
 
       for item <- currState if item.isLastItem do addToTable(item.lookAhead, Reduction(item.production))
@@ -131,11 +140,11 @@ private[parser] object ParseTable:
 
       currStateId += 1
 
-    table.toMap
+    table.iterator.map { case (i, row) => (i, row.toMap) }.toMap
 
   given Showable[ParseTable] = Showable: table =>
-    val symbols = table.keysIterator.map(_.stepSymbol).distinct.toList
-    val states = table.keysIterator.map(_.state).distinct.toList.sorted // todo: SortedSet?
+    val symbols = table.allSymbols
+    val states = table.keysIterator.toList.sorted
 
     def centerText(text: String, width: Int = 10): String =
       if text.length >= width then text
@@ -153,11 +162,12 @@ private[parser] object ParseTable:
       result.append("|")
 
     for i <- states do
+      val row = table(i)
       result.append('\n')
       result.append(centerText(i.toString))
       result.append("|")
       for s <- symbols do
-        result.append(centerText(table.get((i, s)).fold("")(_.show)))
+        result.append(centerText(row.get(s).fold("")(_.show)))
         result.append("|")
     result.append('\n')
     result.result()
@@ -167,32 +177,52 @@ private[parser] object ParseTable:
     def apply(entries: ParseTable)(using quotes: Quotes): Expr[ParseTable] =
       import quotes.reflect.*
 
-      type BuilderTpe = mutable.Builder[
-        ((state: Int, stepSymbol: parser.Symbol), ParseAction),
-        Map[(state: Int, stepSymbol: parser.Symbol), ParseAction],
+      type RowBuilderTpe = mutable.Builder[(parser.Symbol, ParseAction), Map[parser.Symbol, ParseAction]]
+      type OuterBuilderTpe = mutable.Builder[
+        (Int, Map[parser.Symbol, ParseAction]),
+        Map[Int, Map[parser.Symbol, ParseAction]],
       ]
 
-      val symbol = Symbol.newVal(
+      def rowExpr(row: Map[parser.Symbol, ParseAction]): Expr[Map[parser.Symbol, ParseAction]] =
+        if row.isEmpty then '{ Map.empty[parser.Symbol, ParseAction] }
+        else
+          val rowSym = Symbol.newVal(
+            Symbol.spliceOwner,
+            Symbol.freshName("rowBuilder"),
+            TypeRepr.of[RowBuilderTpe],
+            Flags.Synthetic,
+            Symbol.noSymbol,
+          )
+          val rowValDef = ValDef(rowSym, Some('{ Map.newBuilder: RowBuilderTpe }.asTerm))
+          val rowBuilder = Ref(rowSym).asExprOf[RowBuilderTpe]
+
+          val additions = row.toList.map: entry =>
+            '{
+              def avoidTooLargeMethod(): Unit = $rowBuilder += ${ Expr(entry) }
+              avoidTooLargeMethod()
+            }.asTerm
+
+          Block(rowValDef :: additions, '{ $rowBuilder.result() }.asTerm)
+            .asExprOf[Map[parser.Symbol, ParseAction]]
+
+      val outerSym = Symbol.newVal(
         Symbol.spliceOwner,
-        Symbol.freshName("builder"),
-        TypeRepr.of[BuilderTpe],
+        Symbol.freshName("tableBuilder"),
+        TypeRepr.of[OuterBuilderTpe],
         Flags.Synthetic,
         Symbol.noSymbol,
       )
+      val outerValDef = ValDef(outerSym, Some('{ Map.newBuilder: OuterBuilderTpe }.asTerm))
+      val outerBuilder = Ref(outerSym).asExprOf[OuterBuilderTpe]
 
-      val valDef = ValDef(symbol, Some('{ Map.newBuilder: BuilderTpe }.asTerm))
+      val rowAdditions = entries.toList.map: (stateId, row) =>
+        '{
+          def avoidTooLargeMethod(): Unit =
+            $outerBuilder += ((${ Expr(stateId) }, ${ rowExpr(row) }))
+          avoidTooLargeMethod()
+        }.asTerm
 
-      val builder = Ref(symbol).asExprOf[BuilderTpe]
+      val result = '{ $outerBuilder.result() }.asTerm
 
-      val additions = entries
-        .map: entry =>
-          '{
-            def avoidTooLargeMethod(): Unit = $builder += ${ Expr(entry) }
-            avoidTooLargeMethod()
-          }.asTerm
-        .toList
-
-      val result = '{ $builder.result() }.asTerm
-
-      Block(valDef :: additions, result).asExprOf[ParseTable]
+      Block(outerValDef :: rowAdditions, result).asExprOf[ParseTable]
 // $COVERAGE-ON$

--- a/src/alpaca/internal/parser/ParseTable.scala
+++ b/src/alpaca/internal/parser/ParseTable.scala
@@ -188,36 +188,19 @@ private[parser] object ParseTable:
       def rowExpr(row: Row): Expr[Row] =
         if row.isEmpty then '{ Map.empty[parser.Symbol, ParseAction] }
         else
-          val sym = Symbol.newVal(
-            Symbol.spliceOwner,
-            Symbol.freshName("rowBuilder"),
-            TypeRepr.of[RowBuilder],
-            Flags.Synthetic,
-            Symbol.noSymbol,
-          )
-          val valDef = ValDef(sym, Some('{ Map.newBuilder: RowBuilder }.asTerm))
-          val builder = Ref(sym).asExprOf[RowBuilder]
+          ValDef
+            .let(Symbol.spliceOwner, "rowBuilder", '{ Map.newBuilder: RowBuilder }.asTerm): ref =>
+              val builder = ref.asExprOf[RowBuilder]
+              val additions = row.toList.map: entry =>
+                wrapped('{ $builder += ${ Expr(entry) } }).asTerm
+              Block(additions, '{ $builder.result() }.asTerm)
+            .asExprOf[Row]
 
-          val additions = row.map: entry =>
-            wrapped('{ $builder += ${ Expr(entry) } }).asTerm
-
-          Block(valDef :: additions.toList, '{ $builder.result() }.asTerm).asExprOf[Row]
-
-      val tableSym = Symbol.newVal(
-        Symbol.spliceOwner,
-        Symbol.freshName("parseTable"),
-        TypeRepr.of[Array[Row]],
-        Flags.Synthetic,
-        Symbol.noSymbol,
-      )
-      val tableValDef = ValDef(
-        tableSym,
-        Some('{ new Array[Row](${ Expr(entries.length) }) }.asTerm),
-      )
-      val tableRef = Ref(tableSym).asExprOf[Array[Row]]
-
-      val rowAssignments = entries.iterator.zipWithIndex.map: (row, i) =>
-        wrapped('{ $tableRef(${ Expr(i) }) = ${ rowExpr(row) } }).asTerm
-
-      Block(tableValDef :: rowAssignments.toList, '{ $tableRef.asInstanceOf[ParseTable] }.asTerm).asExprOf[ParseTable]
+      ValDef
+        .let(Symbol.spliceOwner, "parseTable", '{ new Array[Row](${ Expr(entries.length) }) }.asTerm): ref =>
+          val tableRef = ref.asExprOf[Array[Row]]
+          val rowAssignments = entries.iterator.zipWithIndex.map: (row, i) =>
+            wrapped('{ $tableRef(${ Expr(i) }) = ${ rowExpr(row) } }).asTerm
+          Block(rowAssignments.toList, '{ $tableRef.asInstanceOf[ParseTable] }.asTerm)
+        .asExprOf[ParseTable]
 // $COVERAGE-ON$

--- a/src/alpaca/internal/parser/ParseTable.scala
+++ b/src/alpaca/internal/parser/ParseTable.scala
@@ -177,16 +177,15 @@ private[parser] object ParseTable:
     def apply(entries: ParseTable)(using quotes: Quotes): Expr[ParseTable] =
       import quotes.reflect.*
 
-      type RowBuilder = mutable.Builder[(parser.Symbol, ParseAction), Map[parser.Symbol, ParseAction]]
+      type Row = Map[parser.Symbol, ParseAction]
+      type RowBuilder = mutable.Builder[(parser.Symbol, ParseAction), Row]
 
-      // Each statement is wrapped in its own local def to keep the enclosing
-      // method under the JVM's 64KB bytecode limit for large grammars.
-      def wrapped(body: Expr[Unit]): Term = '{
+      def wrapped(body: Expr[Unit]): Expr[Unit] = '{
         def avoidTooLargeMethod(): Unit = $body
         avoidTooLargeMethod()
-      }.asTerm
+      }
 
-      def rowExpr(row: Map[parser.Symbol, ParseAction]): Expr[Map[parser.Symbol, ParseAction]] =
+      def rowExpr(row: Row): Expr[Row] =
         if row.isEmpty then '{ Map.empty[parser.Symbol, ParseAction] }
         else
           val sym = Symbol.newVal(
@@ -199,27 +198,26 @@ private[parser] object ParseTable:
           val valDef = ValDef(sym, Some('{ Map.newBuilder: RowBuilder }.asTerm))
           val builder = Ref(sym).asExprOf[RowBuilder]
 
-          val additions = row.toList.map: entry =>
-            wrapped('{ $builder += ${ Expr(entry) } })
+          val additions = row.map: entry =>
+            wrapped('{ $builder += ${ Expr(entry) } }).asTerm
 
-          Block(valDef :: additions, '{ $builder.result() }.asTerm)
-            .asExprOf[Map[parser.Symbol, ParseAction]]
+          Block(valDef :: additions.toList, '{ $builder.result() }.asTerm).asExprOf[Row]
 
       val tableSym = Symbol.newVal(
         Symbol.spliceOwner,
         Symbol.freshName("parseTable"),
-        TypeRepr.of[Array[AnyRef]],
+        TypeRepr.of[Array[Row]],
         Flags.Synthetic,
         Symbol.noSymbol,
       )
       val tableValDef = ValDef(
         tableSym,
-        Some('{ new Array[Map[?, ?]](${ Expr(entries.length) }).asInstanceOf[Array[AnyRef]] }.asTerm),
+        Some('{ new Array[Row](${ Expr(entries.length) }) }.asTerm),
       )
-      val tableRef = Ref(tableSym).asExprOf[Array[AnyRef]]
+      val tableRef = Ref(tableSym).asExprOf[Array[Row]]
 
-      val rowAssignments = entries.toList.zipWithIndex.map: (row, i) =>
-        wrapped('{ $tableRef(${ Expr(i) }) = ${ rowExpr(row) } })
+      val rowAssignments = entries.iterator.zipWithIndex.map: (row, i) =>
+        wrapped('{ $tableRef(${ Expr(i) }) = ${ rowExpr(row) } }).asTerm
 
-      Block(tableValDef :: rowAssignments, '{ $tableRef.asInstanceOf[ParseTable] }.asTerm).asExprOf[ParseTable]
+      Block(tableValDef :: rowAssignments.toList, '{ $tableRef.asInstanceOf[ParseTable] }.asTerm).asExprOf[ParseTable]
 // $COVERAGE-ON$

--- a/src/alpaca/internal/parser/ParseTable.scala
+++ b/src/alpaca/internal/parser/ParseTable.scala
@@ -175,32 +175,18 @@ private[parser] object ParseTable:
   // $COVERAGE-OFF$
   given ToExpr[ParseTable] with
     def apply(entries: ParseTable)(using quotes: Quotes): Expr[ParseTable] =
-      import quotes.reflect.*
-
       type Row = Map[parser.Symbol, ParseAction]
       type RowBuilder = mutable.Builder[(parser.Symbol, ParseAction), Row]
 
-      def wrapped(body: Expr[Unit]): Expr[Unit] = '{
-        def avoidTooLargeMethod(): Unit = $body
-        avoidTooLargeMethod()
-      }
+      def rowExpr(row: Row): Expr[Row] = avoidToLargeMethod[(parser.Symbol, ParseAction), Row, RowBuilder](
+        builder = '{ Map.newBuilder },
+        elements = row.map(Expr(_)),
+        empty = '{ Map.empty },
+      )
 
-      def rowExpr(row: Row): Expr[Row] =
-        if row.isEmpty then '{ Map.empty[parser.Symbol, ParseAction] }
-        else
-          ValDef
-            .let(Symbol.spliceOwner, "rowBuilder", '{ Map.newBuilder: RowBuilder }.asTerm): ref =>
-              val builder = ref.asExprOf[RowBuilder]
-              val additions = row.toList.map: entry =>
-                wrapped('{ $builder += ${ Expr(entry) } }).asTerm
-              Block(additions, '{ $builder.result() }.asTerm)
-            .asExprOf[Row]
-
-      ValDef
-        .let(Symbol.spliceOwner, "parseTable", '{ new Array[Row](${ Expr(entries.length) }) }.asTerm): ref =>
-          val tableRef = ref.asExprOf[Array[Row]]
-          val rowAssignments = entries.iterator.zipWithIndex.map: (row, i) =>
-            wrapped('{ $tableRef(${ Expr(i) }) = ${ rowExpr(row) } }).asTerm
-          Block(rowAssignments.toList, '{ $tableRef.asInstanceOf[ParseTable] }.asTerm)
-        .asExprOf[ParseTable]
+      avoidToLargeMethod[Row, Array[Row], mutable.ArrayBuilder[Row]](
+        builder = '{ mutable.ArrayBuilder.ofRef[Row].tap(_.sizeHint(${ Expr(entries.length) })) },
+        elements = entries.map(rowExpr),
+        empty = '{ Array.empty },
+      )
 // $COVERAGE-ON$


### PR DESCRIPTION
## Summary
- `ParseTable` was `Map[(Int, Symbol), ParseAction]`. Every hot `parseTable(state, symbol)` lookup boxed the key into a fresh `(Int, Symbol)` tuple and hashed both components.
- Restructured as `Array[Map[Symbol, ParseAction]]`. State IDs are dense consecutive integers starting at 0, so the outer layer is a flat array: lookup is one array load plus one symbol hash, with no boxing on the state key.
- The runtime builder produces the `Array` directly from its per-state `ArrayBuffer`. In the macro, a single parametric `mapBuilder` helper replaces the previously duplicated row/outer builder types; a private `ParseTable.fromMap` flips the generated map to an array inside the parser package, where `Symbol` is accessible.

Addresses item 8 in #371.

## Test plan
- [x] \`./mill compile\`
- [x] \`./mill test\`
- [x] \`./mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)