### PR TITLE
fix(parser): State.fromItem dedup checks acc, not the original state

### DIFF
--- a/src/alpaca/internal/parser/State.scala
+++ b/src/alpaca/internal/parser/State.scala
@@ -71,5 +71,5 @@ private[parser] object State:
         .foldLeft(state + item): (acc, production) =>
           lookAheads.foldLeft(acc): (acc, lookAhead) =>
             val item = production.toItem(lookAhead)
-            if state.contains(item) then acc else fromItem(acc, item, productions, firstSet)
+            if acc.contains(item) then acc else fromItem(acc, item, productions, firstSet)
     else state + item


### PR DESCRIPTION
## Summary
Bug from #371 comments: the closure loop in `State.fromItem` checked `state.contains(item)` — the original argument — when deciding whether to recurse. Items added to `acc` during closure computation were invisible to the dedup check, causing redundant recursive calls for every newly-added item.

Fix: check `acc.contains(item)` so newly-added items short-circuit subsequent closures.

## Test plan
- [x] `./mill compile`
- [x] `./mill test`
- [x] `./mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll`

🤖 Generated with [Claude Code](https://claude.com/claude-code)