### PR TITLE
perf(ConflictResolution): ArrayDeque-based BFS queue

### DIFF
--- a/src/alpaca/internal/parser/ConflictResolution.scala
+++ b/src/alpaca/internal/parser/ConflictResolution.scala
@@ -62,15 +62,17 @@ private[parser] object ConflictResolutionTable:
       def winsOver(first: ParseAction, second: ParseAction): Option[ParseAction] =
         val to = second.toConflictKey
         @tailrec
-        def loop(queue: List[ConflictKey], visited: Set[ConflictKey]): Option[ParseAction] = queue match
-          case Nil => None
-          case `to` :: _ => Some(first)
-          case head :: tail =>
-            val current = table.getOrElse(head, Set.empty)
-            val neighbors = current.diff(visited)
-            loop(tail ++ neighbors, visited + head)
+        def loop(queue: mutable.ArrayDeque[ConflictKey], visited: Set[ConflictKey]): Option[ParseAction] =
+          if queue.isEmpty then None
+          else
+            val head = queue.removeHead()
+            if head == to then Some(first)
+            else if visited.contains(head) then loop(queue, visited)
+            else
+              queue.appendAll(table.getOrElse(head, Set.empty))
+              loop(queue, visited + head)
 
-        loop(List(first.toConflictKey), Set())
+        loop(mutable.ArrayDeque[ConflictKey](first.toConflictKey), Set.empty)
 
       winsOver(first, second) orElse winsOver(second, first)
 

--- a/src/alpaca/internal/parser/ConflictResolution.scala
+++ b/src/alpaca/internal/parser/ConflictResolution.scala
@@ -61,18 +61,18 @@ private[parser] object ConflictResolutionTable:
 
       def winsOver(first: ParseAction, second: ParseAction): Option[ParseAction] =
         val to = second.toConflictKey
-        @tailrec
-        def loop(queue: mutable.ArrayDeque[ConflictKey], visited: Set[ConflictKey]): Option[ParseAction] =
-          if queue.isEmpty then None
-          else
-            val head = queue.removeHead()
-            if head == to then Some(first)
-            else if visited.contains(head) then loop(queue, visited)
-            else
-              queue.appendAll(table.getOrElse(head, Set.empty))
-              loop(queue, visited + head)
+        val queue = mutable.ArrayDeque[ConflictKey](first.toConflictKey)
 
-        loop(mutable.ArrayDeque[ConflictKey](first.toConflictKey), Set.empty)
+        @tailrec
+        def loop(visited: Set[ConflictKey]): Option[ParseAction] = queue.removeHeadOption() match
+          case None => None
+          case Some(`to`) => Some(first)
+          case Some(head) if visited contains head => loop(visited)
+          case Some(head) =>
+            table.get(head).foreach(queue.appendAll)
+            loop(visited + head)
+
+        loop(Set.empty)
 
       winsOver(first, second) orElse winsOver(second, first)
 


### PR DESCRIPTION
## Summary
BFS item from the #371 comments.

`winsOver` rebuilt its queue with `tail ++ neighbors` at every BFS step — an O(|tail|) list copy per iteration. On deep precedence chains this dominates.

Swap the functional list queue for a `mutable.ArrayDeque`. Enqueue via `appendAll` and dequeue via `removeHead` are both amortised O(1). Visited nodes are now filtered on dequeue rather than pre-filtered via `diff`, saving a set diff per step.

## Test plan
- [x] `./mill compile`
- [x] `./mill test`
- [x] `./mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll`

🤖 Generated with [Claude Code](https://claude.com/claude-code)