### PR TITLE
perf(parser): swap NEL from List to Vector-backed Seq

### DIFF
--- a/src/alpaca/internal/NEL.scala
+++ b/src/alpaca/internal/NEL.scala
@@ -2,11 +2,12 @@ package alpaca
 package internal
 
 /**
- * An opaque type representing a non-empty list.
+ * An opaque type representing a non-empty sequence.
  *
- * This is a type-safe wrapper around List that guarantees at compile time
- * that the list contains at least one element. It is a subtype of List[A]
- * so it can be used wherever a List is expected.
+ * Backed by [[Vector]] and exposed as a subtype of [[Seq]], with a
+ * compile-time guarantee that it contains at least one element. Vector
+ * gives O(1) `size` and effectively O(1) indexed access, which matters
+ * on LR hot paths (`Item.isLastItem`, reduction dispatch, `nextSymbol`).
  *
  * @tparam A the element type
  */
@@ -34,14 +35,14 @@ private[alpaca] object NEL:
   def unapply[A](list: NEL[A]): (A, Seq[A]) = (list.head, list.tail)
 
   /**
-   * Unsafely converts a List to a NEL.
+   * Unsafely converts a [[Seq]] to a NEL.
    *
-   * This method performs a runtime check to ensure the list is non-empty.
+   * This method performs a runtime check to ensure the sequence is non-empty.
    * Use with caution as it can throw an exception.
    *
-   * @param list the list to convert
-   * @return the list as a NEL
-   * @throws IllegalArgumentException if the list is empty
+   * @param list the sequence to convert
+   * @return the sequence as a NEL
+   * @throws IllegalArgumentException if the sequence is empty
    */
   private[internal] def unsafe[A](list: Seq[A]): NEL[A] =
     if list.isEmpty then throw IllegalArgumentException("Empty list cannot be converted to NEL")
@@ -50,5 +51,5 @@ private[alpaca] object NEL:
   // $COVERAGE-OFF$
   private[internal] given [A: {Type, ToExpr}]: ToExpr[NEL[A]] with
     def apply(x: NEL[A])(using Quotes): Expr[NEL[A]] =
-      '{ NEL(${ Expr(x.head) }, ${ ToExpr.SeqToExpr(x.tail) } *) }
+      '{ NEL(${ Expr(x.head) }, ${ ToExpr.SeqToExpr(x.tail) }*) }
 // $COVERAGE-ON$

--- a/src/alpaca/internal/NEL.scala
+++ b/src/alpaca/internal/NEL.scala
@@ -10,7 +10,7 @@ package internal
  *
  * @tparam A the element type
  */
-opaque private[alpaca] type NEL[+A] <: List[A] = List[A]
+opaque private[alpaca] type NEL[+A] <: Seq[A] = Vector[A]
 
 private[alpaca] object NEL:
 
@@ -21,7 +21,7 @@ private[alpaca] object NEL:
    * @param tail additional elements (optional)
    * @return a new NEL
    */
-  inline def apply[A](inline head: A, inline tail: A*): NEL[A] = head :: tail.toList
+  inline def apply[A](inline head: A, inline tail: A*): NEL[A] = head +: tail.toVector
 
   /**
    * Pattern matching extractor for NEL.
@@ -31,7 +31,7 @@ private[alpaca] object NEL:
    * @param list the list to deconstruct
    * @return (head, tail)
    */
-  def unapply[A](list: NEL[A]): (A, List[A]) = (list.head, list.tail)
+  def unapply[A](list: NEL[A]): (A, Seq[A]) = (list.head, list.tail)
 
   /**
    * Unsafely converts a List to a NEL.
@@ -43,12 +43,12 @@ private[alpaca] object NEL:
    * @return the list as a NEL
    * @throws IllegalArgumentException if the list is empty
    */
-  private[internal] def unsafe[A](list: List[A]): NEL[A] =
+  private[internal] def unsafe[A](list: Seq[A]): NEL[A] =
     if list.isEmpty then throw IllegalArgumentException("Empty list cannot be converted to NEL")
-    list
+    list.toVector
 
   // $COVERAGE-OFF$
   private[internal] given [A: {Type, ToExpr}]: ToExpr[NEL[A]] with
     def apply(x: NEL[A])(using Quotes): Expr[NEL[A]] =
-      '{ NEL(${ Expr(x.head) }, ${ ToExpr.ListToExpr(x.tail) }*) }
+      '{ NEL(${ Expr(x.head) }, ${ ToExpr.SeqToExpr(x.tail) } *) }
 // $COVERAGE-ON$

--- a/src/alpaca/internal/parser/FirstSet.scala
+++ b/src/alpaca/internal/parser/FirstSet.scala
@@ -45,8 +45,8 @@ private[parser] object FirstSet:
         val newFirstSet = firstSet.updated(lhs, firstSet(lhs) ++ (firstSet(head) - Symbol.Empty))
 
         val production = tail match
-          case head :: next => Production.NonEmpty(lhs, NEL(head, next*))
-          case Nil => Production.Empty(lhs)
+          case head +: next => Production.NonEmpty(lhs, NEL(head, next*))
+          case _ => Production.Empty(lhs)
 
         if firstSet(head).contains(Symbol.Empty)
         then addImports(newFirstSet, production)

--- a/src/alpaca/internal/parser/Item.scala
+++ b/src/alpaca/internal/parser/Item.scala
@@ -39,7 +39,7 @@ private[parser] final case class Item(production: Production, dotPosition: Int, 
 
   /** Whether the dot is at the end of the production. */
   val isLastItem: Boolean = production match
-    case Production.NonEmpty(_, rhs, name) => rhs.sizeIs == dotPosition
+    case _: Production.NonEmpty => production.rhsSize == dotPosition
     case _: Production.Empty => true
 
   /**

--- a/src/alpaca/internal/parser/Item.scala
+++ b/src/alpaca/internal/parser/Item.scala
@@ -10,9 +10,9 @@ package parser
  * lookahead terminal. For example: `E -> E • + T, $` means we have
  * recognized `E` and expect `+` next, with `$` as the lookahead.
  *
- * @param production the grammar production
+ * @param production  the grammar production
  * @param dotPosition the position of the dot (0 to production.rhs.size)
- * @param lookAhead the lookahead terminal
+ * @param lookAhead   the lookahead terminal
  */
 private[parser] final case class Item(production: Production, dotPosition: Int, lookAhead: Terminal)(using Log):
   production match
@@ -39,7 +39,7 @@ private[parser] final case class Item(production: Production, dotPosition: Int, 
 
   /** Whether the dot is at the end of the production. */
   val isLastItem: Boolean = production match
-    case _: Production.NonEmpty => production.rhsSize == dotPosition
+    case Production.NonEmpty(_, rhs, name) => rhs.sizeIs == dotPosition
     case _: Production.Empty => true
 
   /**

--- a/src/alpaca/internal/parser/Parser.scala
+++ b/src/alpaca/internal/parser/Parser.scala
@@ -113,7 +113,7 @@ abstract class Parser[Ctx <: ParserCtx](
           nodeStack += Node.Token(input(pos))
           loop(pos + 1)
 
-        case ParseAction.Reduction(prod@Production.NonEmpty(lhs, rhs, name)) =>
+        case ParseAction.Reduction(prod @ Production.NonEmpty(lhs, rhs, name)) =>
           val n = rhs.size
           val newStateIdx = stateStack(stateStack.size - 1 - n)
 
@@ -133,7 +133,7 @@ abstract class Parser[Ctx <: ParserCtx](
         case ParseAction.Reduction(Production.Empty(Symbol.Start, name)) if stateStack.last == 0 =>
           nodeStack.last
 
-        case ParseAction.Reduction(prod@Production.Empty(lhs, name)) =>
+        case ParseAction.Reduction(prod @ Production.Empty(lhs, name)) =>
           val ParseAction.Shift(gotoState) = tables.parseTable(stateStack.last, lhs).runtimeChecked
           val result = tables.actionTable(prod)(ctx, RevertedArray.empty)
           stateStack += gotoState
@@ -165,7 +165,7 @@ def productionImpl(using quotes: Quotes): Expr[ProductionSelector] = withLog:
           case decl if decl.typeRef <:< TypeRepr.of[Rule[?]] => decl.tree
 
         val extractName: PartialFunction[Expr[Rule[?]], Seq[String]] =
-          case '{ rule(${ Varargs(cases) } *) } =>
+          case '{ rule(${ Varargs(cases) }*) } =>
             cases.flatMap:
               case '{ ($name: ValidName).apply($_ : ProductionDefinition[?]) } => name.value
               case _ => None
@@ -189,7 +189,7 @@ def productionImpl(using quotes: Quotes): Expr[ProductionSelector] = withLog:
     )
     .runtimeChecked match
     case ('[refinement], '[fields]) =>
-      '{ DummyProductionSelector.asInstanceOf[ProductionSelector {type Fields = fields} & refinement] }
+      '{ DummyProductionSelector.asInstanceOf[ProductionSelector { type Fields = fields } & refinement] }
 
 private object DummyProductionSelector extends ProductionSelector:
   override def selectDynamic(name: String): Any = dummy

--- a/src/alpaca/internal/parser/Parser.scala
+++ b/src/alpaca/internal/parser/Parser.scala
@@ -113,7 +113,7 @@ abstract class Parser[Ctx <: ParserCtx](
           nodeStack += Node.Token(input(pos))
           loop(pos + 1)
 
-        case ParseAction.Reduction(prod@Production.NonEmpty(lhs, rhs, name)) =>
+        case ParseAction.Reduction(prod @ Production.NonEmpty(lhs, rhs, name)) =>
           val n = prod.rhs.size
           val newStateIdx = stateStack(stateStack.size - 1 - n)
 
@@ -133,7 +133,7 @@ abstract class Parser[Ctx <: ParserCtx](
         case ParseAction.Reduction(Production.Empty(Symbol.Start, name)) if stateStack.last == 0 =>
           nodeStack.last
 
-        case ParseAction.Reduction(prod@Production.Empty(lhs, name)) =>
+        case ParseAction.Reduction(prod @ Production.Empty(lhs, name)) =>
           val ParseAction.Shift(gotoState) = tables.parseTable(stateStack.last, lhs).runtimeChecked
           val result = tables.actionTable(prod)(ctx, RevertedArray.empty)
           stateStack += gotoState
@@ -165,7 +165,7 @@ def productionImpl(using quotes: Quotes): Expr[ProductionSelector] = withLog:
           case decl if decl.typeRef <:< TypeRepr.of[Rule[?]] => decl.tree
 
         val extractName: PartialFunction[Expr[Rule[?]], Seq[String]] =
-          case '{ rule(${ Varargs(cases) } *) } =>
+          case '{ rule(${ Varargs(cases) }*) } =>
             cases.flatMap:
               case '{ ($name: ValidName).apply($_ : ProductionDefinition[?]) } => name.value
               case _ => None
@@ -189,7 +189,7 @@ def productionImpl(using quotes: Quotes): Expr[ProductionSelector] = withLog:
     )
     .runtimeChecked match
     case ('[refinement], '[fields]) =>
-      '{ DummyProductionSelector.asInstanceOf[ProductionSelector {type Fields = fields} & refinement] }
+      '{ DummyProductionSelector.asInstanceOf[ProductionSelector { type Fields = fields } & refinement] }
 
 private object DummyProductionSelector extends ProductionSelector:
   override def selectDynamic(name: String): Any = dummy

--- a/src/alpaca/internal/parser/Parser.scala
+++ b/src/alpaca/internal/parser/Parser.scala
@@ -85,7 +85,7 @@ abstract class Parser[Ctx <: ParserCtx](
    * parse the input lexemes using an LR parsing algorithm.
    *
    * @tparam R the result type
-   * @param lexemes   the list of lexemes to parse
+   * @param lexemes the list of lexemes to parse
    * @return a tuple of (context, result), where result may be null on parse failure
    */
   private[alpaca] def unsafeParse[R](lexemes: List[Lexeme[?, ?]]): (ctx: Ctx, result: R | Null) =
@@ -113,8 +113,8 @@ abstract class Parser[Ctx <: ParserCtx](
           nodeStack += Node.Token(input(pos))
           loop(pos + 1)
 
-        case ParseAction.Reduction(prod @ Production.NonEmpty(lhs, rhs, name)) =>
-          val n = prod.rhsSize
+        case ParseAction.Reduction(prod@Production.NonEmpty(lhs, rhs, name)) =>
+          val n = prod.rhs.size
           val newStateIdx = stateStack(stateStack.size - 1 - n)
 
           if lhs == Symbol.Start && newStateIdx == 0 then nodeStack.last
@@ -133,7 +133,7 @@ abstract class Parser[Ctx <: ParserCtx](
         case ParseAction.Reduction(Production.Empty(Symbol.Start, name)) if stateStack.last == 0 =>
           nodeStack.last
 
-        case ParseAction.Reduction(prod @ Production.Empty(lhs, name)) =>
+        case ParseAction.Reduction(prod@Production.Empty(lhs, name)) =>
           val ParseAction.Shift(gotoState) = tables.parseTable(stateStack.last, lhs).runtimeChecked
           val result = tables.actionTable(prod)(ctx, RevertedArray.empty)
           stateStack += gotoState
@@ -165,7 +165,7 @@ def productionImpl(using quotes: Quotes): Expr[ProductionSelector] = withLog:
           case decl if decl.typeRef <:< TypeRepr.of[Rule[?]] => decl.tree
 
         val extractName: PartialFunction[Expr[Rule[?]], Seq[String]] =
-          case '{ rule(${ Varargs(cases) }*) } =>
+          case '{ rule(${ Varargs(cases) } *) } =>
             cases.flatMap:
               case '{ ($name: ValidName).apply($_ : ProductionDefinition[?]) } => name.value
               case _ => None
@@ -189,7 +189,7 @@ def productionImpl(using quotes: Quotes): Expr[ProductionSelector] = withLog:
     )
     .runtimeChecked match
     case ('[refinement], '[fields]) =>
-      '{ DummyProductionSelector.asInstanceOf[ProductionSelector { type Fields = fields } & refinement] }
+      '{ DummyProductionSelector.asInstanceOf[ProductionSelector {type Fields = fields} & refinement] }
 
 private object DummyProductionSelector extends ProductionSelector:
   override def selectDynamic(name: String): Any = dummy

--- a/src/alpaca/internal/parser/Parser.scala
+++ b/src/alpaca/internal/parser/Parser.scala
@@ -114,7 +114,7 @@ abstract class Parser[Ctx <: ParserCtx](
           loop(pos + 1)
 
         case ParseAction.Reduction(prod @ Production.NonEmpty(lhs, rhs, name)) =>
-          val n = rhs.size
+          val n = prod.rhsSize
           val newStateIdx = stateStack(stateStack.size - 1 - n)
 
           if lhs == Symbol.Start && newStateIdx == 0 then nodeStack.last

--- a/src/alpaca/internal/parser/Parser.scala
+++ b/src/alpaca/internal/parser/Parser.scala
@@ -113,8 +113,8 @@ abstract class Parser[Ctx <: ParserCtx](
           nodeStack += Node.Token(input(pos))
           loop(pos + 1)
 
-        case ParseAction.Reduction(prod @ Production.NonEmpty(lhs, rhs, name)) =>
-          val n = prod.rhs.size
+        case ParseAction.Reduction(prod@Production.NonEmpty(lhs, rhs, name)) =>
+          val n = rhs.size
           val newStateIdx = stateStack(stateStack.size - 1 - n)
 
           if lhs == Symbol.Start && newStateIdx == 0 then nodeStack.last
@@ -133,7 +133,7 @@ abstract class Parser[Ctx <: ParserCtx](
         case ParseAction.Reduction(Production.Empty(Symbol.Start, name)) if stateStack.last == 0 =>
           nodeStack.last
 
-        case ParseAction.Reduction(prod @ Production.Empty(lhs, name)) =>
+        case ParseAction.Reduction(prod@Production.Empty(lhs, name)) =>
           val ParseAction.Shift(gotoState) = tables.parseTable(stateStack.last, lhs).runtimeChecked
           val result = tables.actionTable(prod)(ctx, RevertedArray.empty)
           stateStack += gotoState
@@ -165,7 +165,7 @@ def productionImpl(using quotes: Quotes): Expr[ProductionSelector] = withLog:
           case decl if decl.typeRef <:< TypeRepr.of[Rule[?]] => decl.tree
 
         val extractName: PartialFunction[Expr[Rule[?]], Seq[String]] =
-          case '{ rule(${ Varargs(cases) }*) } =>
+          case '{ rule(${ Varargs(cases) } *) } =>
             cases.flatMap:
               case '{ ($name: ValidName).apply($_ : ProductionDefinition[?]) } => name.value
               case _ => None
@@ -189,7 +189,7 @@ def productionImpl(using quotes: Quotes): Expr[ProductionSelector] = withLog:
     )
     .runtimeChecked match
     case ('[refinement], '[fields]) =>
-      '{ DummyProductionSelector.asInstanceOf[ProductionSelector { type Fields = fields } & refinement] }
+      '{ DummyProductionSelector.asInstanceOf[ProductionSelector {type Fields = fields} & refinement] }
 
 private object DummyProductionSelector extends ProductionSelector:
   override def selectDynamic(name: String): Any = dummy

--- a/src/alpaca/internal/parser/Production.scala
+++ b/src/alpaca/internal/parser/Production.scala
@@ -20,6 +20,15 @@ private[alpaca] enum Production(val rhs: NEL[Symbol.NonEmpty] | Symbol.Empty.typ
   val name: ValidName | Null
 
   /**
+   * Cached length of `rhs`. `NEL` is a `List`, so `rhs.size` is O(n); this
+   * memoises the result per production and is the value to query on LR hot
+   * paths (`Item.isLastItem`, reduction dispatch).
+   */
+  lazy val rhsSize: Int = rhs match
+    case list: List[?] => list.size
+    case _ => 0
+
+  /**
    * Converts this production to an LR(0) item with a given lookahead.
    *
    * @param lookAhead the lookahead terminal (defaults to EOF)

--- a/src/alpaca/internal/parser/Production.scala
+++ b/src/alpaca/internal/parser/Production.scala
@@ -20,15 +20,6 @@ private[alpaca] enum Production(val rhs: NEL[Symbol.NonEmpty] | Symbol.Empty.typ
   val name: ValidName | Null
 
   /**
-   * Cached length of `rhs`. `NEL` is a `List`, so `rhs.size` is O(n); this
-   * memoises the result per production and is the value to query on LR hot
-   * paths (`Item.isLastItem`, reduction dispatch).
-   */
-  lazy val rhsSize: Int = rhs match
-    case list: List[?] => list.size
-    case _ => 0
-
-  /**
    * Converts this production to an LR(0) item with a given lookahead.
    *
    * @param lookAhead the lookahead terminal (defaults to EOF)
@@ -57,7 +48,7 @@ private[alpaca] object Production:
     case Empty(lhs, name: String) => show"$lhs -> ${Symbol.Empty} ($name)"
 
   /** ToExpr instance for lifting productions to compile-time expressions. */
-// $COVERAGE-OFF$
+  // $COVERAGE-OFF$
   given ToExpr[Production] with
     def apply(x: Production)(using Quotes): Expr[Production] = x match
       case NonEmpty(lhs, rhs, name) => '{ NonEmpty(${ Expr(lhs) }, ${ Expr(rhs) }, ${ Expr(name) }) }


### PR DESCRIPTION
## Summary
Addresses the NEL O(n) indexing item from the #371 comments.

`NEL` was an opaque alias over `List`, so on LR hot paths we paid O(n) for `rhs.size` (`Item.isLastItem`, reduction dispatch) and O(k) for `rhs(dotPosition)` (`Item.nextSymbol`). Productions with long RHS — e.g. those generated by `.SeparatedBy` — paid this on every LR step.

Swap the backing to `Vector[A]`, exposed as a subtype of `Seq[A]`:

- `size` is O(1).
- Indexed access is effectively O(1) (O(log₃₂ n)).
- The non-empty compile-time guarantee is preserved.

## Knock-on changes
- `FirstSet.addImports` pattern-matched `tail` with `::`/`Nil`, which is `List`-specific and would throw `MatchError` on a Vector-backed tail. Swap to the Seq-friendly `+:` extractor.
- Scaladoc on `NEL` and `NEL.unsafe` updated to reflect the Vector/Seq semantics.
- Minor style alignment in `Item`, `Parser`, `Production` carried along with the refactor.

## Follow-ups
Array-backed RHS (also suggested in the ticket) is deferred — Vector already buys back the asymptotic wins; a tighter representation can come later if profiling justifies it.

## Test plan
- [x] `./mill compile`
- [x] `./mill test`
- [x] `./mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll`