### PR TITLE
bench: add flat_list and deep_nested scenarios to AlpacaBenchmark

### DIFF
--- a/benchmarks/alpaca/src/AlpacaBenchmark.scala
+++ b/benchmarks/alpaca/src/AlpacaBenchmark.scala
@@ -23,6 +23,8 @@ class AlpacaBenchmark:
       "iterative_json",
       "recursive_json",
       "big_grammar",
+      "flat_list",
+      "deep_nested",
     ),
   )
   var scenario: String = uninitialized
@@ -30,7 +32,7 @@ class AlpacaBenchmark:
   @Param(Array("100", "500", "1000", "2000", "5000", "10000"))
   var size: String = uninitialized
 
-  // Input text loaded from file
+  // Input text loaded from file (or synthesised in-memory for flat_list / deep_nested)
   private var input: String = uninitialized
 
   // Pre-built closures that call the correct lexer/parser for this scenario.
@@ -44,21 +46,33 @@ class AlpacaBenchmark:
 
   @Setup(Level.Trial)
   def setup(): Unit =
-    val fileName = s"${scenario}_$size.txt"
-    // Walk up from CWD to find benchmarks/inputs/ — JMH fork CWD varies by Mill version
-    val cwd = Paths.get("").toAbsolutePath
-    val candidates = Iterator
-      .iterate(cwd)(_.getParent)
-      .takeWhile(_ != null)
-      .take(5)
-      .flatMap { dir =>
-        Seq(dir.resolve(s"inputs/$fileName"), dir.resolve(s"benchmarks/inputs/$fileName"))
-      }
-      .toSeq
-    val inputPath = candidates
-      .find(Files.exists(_))
-      .getOrElse(sys.error(s"Input file not found for $scenario/$size. CWD=$cwd, tried: ${candidates.mkString(", ")}"))
-    input = new String(Files.readAllBytes(inputPath))
+    val n = size.toInt
+
+    scenario match
+      case "flat_list" =>
+        // `n` tokens of `a` separated by spaces: stresses the LR reduction loop
+        // on a single long left-recursive production.
+        input = ("a " * n).trim
+      case "deep_nested" =>
+        // `n` levels of nested parens around a single `0`: stresses the parser's
+        // recursive reduction chain.
+        input = "(" * n + "0" + ")" * n
+      case _ =>
+        val fileName = s"${scenario}_$size.txt"
+        // Walk up from CWD to find benchmarks/inputs/ — JMH fork CWD varies by Mill version
+        val cwd = Paths.get("").toAbsolutePath
+        val candidates = Iterator
+          .iterate(cwd)(_.getParent)
+          .takeWhile(_ != null)
+          .take(5)
+          .flatMap: dir =>
+            Seq(dir.resolve(s"inputs/$fileName"), dir.resolve(s"benchmarks/inputs/$fileName"))
+          .toSeq
+        val inputPath = candidates
+          .find(Files.exists(_))
+          .getOrElse:
+            sys.error(s"Input file not found for $scenario/$size. CWD=$cwd, tried: ${candidates.mkString(", ")}")
+        input = new String(Files.readAllBytes(inputPath))
 
     scenario match
       case s if s.contains("math") =>
@@ -93,6 +107,28 @@ class AlpacaBenchmark:
           BigGrammarParser.parse(tokens)
         val (_, preTokenized) = BigGrammarLexer.tokenize(input)
         preTokenizedParseFn = () => BigGrammarParser.parse(preTokenized)
+
+      case "flat_list" =>
+        lexFn = (in: String) => FlatListLexer.tokenize(in)
+        parseFn = (in: String) =>
+          val (_, tokens) = FlatListLexer.tokenize(in)
+          FlatListParser.parse(tokens)
+        fullParseFn = (in: String) =>
+          val (_, tokens) = FlatListLexer.tokenize(in)
+          FlatListParser.parse(tokens)
+        val (_, preTokenized) = FlatListLexer.tokenize(input)
+        preTokenizedParseFn = () => FlatListParser.parse(preTokenized)
+
+      case "deep_nested" =>
+        lexFn = (in: String) => DeepNestedLexer.tokenize(in)
+        parseFn = (in: String) =>
+          val (_, tokens) = DeepNestedLexer.tokenize(in)
+          DeepNestedParser.parse(tokens)
+        fullParseFn = (in: String) =>
+          val (_, tokens) = DeepNestedLexer.tokenize(in)
+          DeepNestedParser.parse(tokens)
+        val (_, preTokenized) = DeepNestedLexer.tokenize(input)
+        preTokenizedParseFn = () => DeepNestedParser.parse(preTokenized)
 
   @Benchmark
   def lex(bh: Blackhole): Unit =

--- a/benchmarks/alpaca/src/DeepNestedParser.scala
+++ b/benchmarks/alpaca/src/DeepNestedParser.scala
@@ -1,0 +1,18 @@
+package bench.alpaca
+
+import alpaca.*
+
+val DeepNestedLexer = lexer {
+  case "\\s+" => Token.Ignored
+  case x @ ("\\(" | "\\)") => Token[x.type]
+  case num @ "\\d+" => Token["num"](num.toInt)
+}
+
+object DeepNestedParser extends Parser:
+  val Expr: Rule[Int] = rule(
+    { case (DeepNestedLexer.`\\(`(_), Expr(a), DeepNestedLexer.`\\)`(_)) => a },
+    { case DeepNestedLexer.num(n) => n.value },
+  )
+
+  val root: Rule[Int] = rule:
+    case Expr(v) => v

--- a/benchmarks/alpaca/src/FlatListParser.scala
+++ b/benchmarks/alpaca/src/FlatListParser.scala
@@ -1,0 +1,12 @@
+package bench.alpaca
+
+import alpaca.*
+
+val FlatListLexer = lexer {
+  case "\\s+" => Token.Ignored
+  case "a" => Token["a"]
+}
+
+object FlatListParser extends Parser:
+  val root: Rule[List[Any]] = rule:
+    case FlatListLexer.a.List(items) => items


### PR DESCRIPTION
## Summary
Addresses the remaining part of the ParserCoreBenchmark item in #371 — the `pureParseOnly` pre-tokenized path and the size parametrisation are already on master; only the new scenarios were missing.

Two new scenarios alongside the existing math / json / big_grammar:

- **flat_list** — N tokens of \`a\` separated by spaces. Stresses the LR reduction loop on a single long left-recursive production. Grammar: `root → a.List`.
- **deep_nested** — N levels of nested parens wrapping a single \`0\`. Stresses deep reduction chains. Grammar: `Expr → ( Expr ) | num`.

Inputs are synthesised in \`@Setup\` from the \`size\` parameter, so no new files under \`benchmarks/inputs/\` are required; the existing scenarios continue to read from disk.

## Known blocker (pre-existing, out of scope)
The \`benchmarks.alpaca\` module does not currently compile on master:

\`\`\`
variable lastRawMatched in trait LexerCtx cannot be accessed as a member of (...) from anonymous class alpaca.internal.lexer.Tokenization[...]
  private[alpaca] variable lastRawMatched can only be accessed from package alpaca.
\`\`\`

The \`lexer { ... }\` macro emits direct access to \`private[alpaca]\` members at the use site; the benchmark module lives in \`bench.alpaca\` and cannot see them. This change does not introduce or fix that — it should be a separate PR (e.g. move the benchmark package under \`alpaca.benchmarks\`, or add a public accessor).

## Test plan
- [x] \`./mill compile\`
- [x] \`./mill test\`
- [x] \`./mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll\`
- [ ] \`./mill benchmarks.alpaca.runJmh\` — blocked on the pre-existing visibility issue above