### PR TITLE
fix(LexerCtx): make lastRawMatched source-public

### DIFF
--- a/src/alpaca/lexer.scala
+++ b/src/alpaca/lexer.scala
@@ -107,10 +107,10 @@ trait LexerCtx extends Product:
 
   /**
    * The raw string that was matched for the last token.
-   * @note This is for internal use only and should not be accessed directly.
+   * @note Internal API — the lexer macro reads this field at user-site, so it
+   *       has to be source-visible outside the `alpaca` package.
    */
-  @publicInBinary
-  private[alpaca] var lastRawMatched: String = compiletime.uninitialized
+  var lastRawMatched: String = compiletime.uninitialized
 
   /**
    * The remaining text to be tokenized.


### PR DESCRIPTION
## Summary
The `lexer { ... }` macro emits direct reads of `ctx.lastRawMatched` into user code (`Select.unique(newCtx, "lastRawMatched")` and `_.lastRawMatched` in `Lexer.scala`). While the field was `private[alpaca]`, any project that places a lexer outside the `alpaca` package — e.g. the `benchmarks.alpaca` module (`package bench.alpaca`) — failed to compile with:

```
variable lastRawMatched can only be accessed from package alpaca
```

## Approach
Drop `private[alpaca]` on `lastRawMatched`. It stays `@publicInBinary` and the scaladoc marks it as internal API — the macro is the only intended writer — but source visibility has to match where the macro expands.

`lastLexeme` and `text` keep `private[alpaca]`; the macro never emits reads of those at user sites.

Unblocks the `benchmarks.alpaca` module (needed to run #383).

## Test plan
- [x] `./mill compile`
- [x] `./mill test`
- [x] `./mill benchmarks.alpaca.compile` — now compiles
- [x] `./mill mill.scalalib.scalafmt.ScalafmtModule/checkFormatAll`