### PR TITLE
refactor(RegexChecker): drop dregex, use cross-platform Subset

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -86,7 +86,6 @@ object `package` extends ScalaModule with ScoverageModule with SonatypeCentralPu
   )
 
   def mvnDeps = Seq(
-    mvn"com.github.marianobarrios:dregex:0.9.0",
     mvn"org.jparsec:jparsec:3.1",
     mvn"org.slf4j:slf4j-api:2.0.17",
     mvn"org.slf4j:slf4j-simple:2.0.17",

--- a/src/alpaca/internal/lexer/CompileNameAndPattern.scala
+++ b/src/alpaca/internal/lexer/CompileNameAndPattern.scala
@@ -2,6 +2,8 @@ package alpaca
 package internal
 package lexer
 
+import alpaca.internal.lexer.regex.{Regex, RegexParseError, RegexParser}
+
 import scala.annotation.tailrec
 
 /**
@@ -67,8 +69,19 @@ private[lexer] final class CompileNameAndPattern[Q <: Quotes](using val quotes: 
           logger.trace(show"matched named token with name=$str and alternatives ${alternatives.mkShow}")
           val patterns = alternatives.unsafeMap:
             case Literal(StringConstant(str)) => str
-          RegexChecker.checkPatterns(patterns)
-          RegexChecker.checkPatterns(patterns.reverse)
+          val items: List[(name: String, regex: Regex)] = patterns.map: p =>
+            RegexParser.parse(p) match
+              case Right(r) => (name = p, regex = r)
+              case Left(err: RegexParseError.UnsupportedFeature) =>
+                quotes.reflect.report.errorAndAbort(
+                  show"Unsupported regex feature `${err.feature}` at position ${err.position.toString} in pattern \"$p\"",
+                )
+              case Left(err: RegexParseError.InvalidSyntax) =>
+                quotes.reflect.report.errorAndAbort(
+                  show"Invalid regex pattern \"$p\" at position ${err.position.toString}: ${err.message}",
+                )
+          RegexChecker.checkRegexes(items)
+          RegexChecker.checkRegexes(items.reverse)
           TokenInfo(str, patterns.mkShow("|")) :: Nil
         case x => raiseShouldNeverBeCalled[List[(Type[? <: ValidName], TokenInfo)]](x.toString)
 

--- a/src/alpaca/internal/lexer/Lexer.scala
+++ b/src/alpaca/internal/lexer/Lexer.scala
@@ -3,6 +3,7 @@ package internal
 package lexer
 
 import alpaca.Token as TokenDef
+import alpaca.internal.lexer.regex.{Regex, RegexParseError, RegexParser}
 
 import java.util.regex.{Pattern, PatternSyntaxException}
 import scala.NamedTuple.{AnyNamedTuple, NamedTuple}
@@ -93,10 +94,6 @@ def lexerImpl[Ctx <: LexerCtx: Type, lexemeFields <: AnyNamedTuple: Type](
         .getOrElse(raiseShouldNeverBeCalled[List[(TokenInfo, Expr[Token[?, Ctx, ?]])]](body))
         .unzip
 
-      val patterns = infos.map(_.pattern)
-      RegexChecker.checkPatterns(patterns)
-      RegexChecker.checkPatterns(patterns.reverse)
-
       (
         tokens = accTokens ::: tokens.map:
           case '{ type name <: ValidName; type tokenTpe <: Token[name, Ctx, ?]; $token: tokenTpe } =>
@@ -117,8 +114,25 @@ def lexerImpl[Ctx <: LexerCtx: Type, lexemeFields <: AnyNamedTuple: Type](
         show"Token name \"$name\" is defined ${duplicates.size.toString} times. Combine the patterns into a single case using alternatives, e.g.: case x @ (\"pattern1\" | \"pattern2\") => Token[x]",
       )
 
+  logger.trace("parsing regex patterns")
+  val parsedRegexes: List[Regex] = infos.map: info =>
+    RegexParser.parse(info.pattern) match
+      case Right(r) => r
+      case Left(err: RegexParseError.UnsupportedFeature) =>
+        report.errorAndAbort(
+          show"Unsupported regex feature `${err.feature}` at position ${err.position.toString} in pattern \"${info.pattern}\" for token \"${info.name}\"",
+        )
+      case Left(err: RegexParseError.InvalidSyntax) =>
+        report.errorAndAbort(
+          show"Invalid regex pattern \"${info.pattern}\" for token \"${info.name}\" at position ${err.position.toString}: ${err.message}. If you meant to match a literal character, escape it with a backslash (e.g., \"\\\\+\" instead of \"+\")",
+        )
+
   logger.trace("checking regex patterns")
-  RegexChecker.checkPatterns(infos.map(_.pattern))
+  val items: List[(name: String, regex: Regex)] = infos
+    .zip(parsedRegexes)
+    .map: (info, r) =>
+      (name = info.name, regex = r)
+  RegexChecker.checkRegexes(items)
 
   val fields = tokens.map((expr, name) => (name, expr.asTerm.tpe))
   val types = Refined(

--- a/src/alpaca/internal/lexer/RegexChecker.scala
+++ b/src/alpaca/internal/lexer/RegexChecker.scala
@@ -2,34 +2,29 @@ package alpaca
 package internal
 package lexer
 
-import dregex.Regex
-
-import scala.jdk.CollectionConverters.SeqHasAsJava
+import alpaca.internal.lexer.regex.{Regex, Subset}
 
 /**
- * Utility for checking regex patterns for shadowing issues.
+ * Cross-platform shadow detection for token regex patterns.
  *
- * This object provides methods to check if any token patterns are
- * shadowed by others, which would mean they could never be matched.
+ * A pattern is shadowed if every string it matches is also matched (as a prefix)
+ * by an earlier pattern, meaning the earlier pattern would always be selected first.
+ * Implemented via Brzozowski-derivative DFA emptiness check on `L(later · Σ*) ⊆ L(earlier · Σ*)`.
  */
 private[lexer] object RegexChecker:
 
   /**
-   * Checks a sequence of regex patterns for shadowing.
+   * Checks a priority-ordered sequence of pre-parsed regexes for shadowing.
    *
-   * A pattern is shadowed if it is a subset of an earlier pattern,
-   * meaning the earlier pattern would always match first and the
-   * shadowed pattern would never be used.
-   *
-   * @param patterns the regex patterns to check.
+   * @throws ShadowException if any pattern is shadowed by an earlier one.
    */
-  def checkPatterns(patterns: List[String])(using Log): Unit = patterns match // todo: find better way
+  def checkRegexes(items: List[(name: String, regex: Regex)])(using Log): Unit = items match
     case Nil => ()
-    case patterns =>
+    case _ =>
       logger.trace("checking regex patterns for shadowing...")
-      val regexes = Regex.compile(patterns.map(_ + ".*").asJava)
-
-      for
-        i <- patterns.indices
-        j <- (i + 1) until regexes.size
-      do if regexes.get(j).isSubsetOf(regexes.get(i)) then throw ShadowException(patterns(j), patterns(i))
+      val withSuffix = items.map((name, r) => name -> Subset.of(r).withAnySuffix)
+      withSuffix.tails.foreach:
+        case Nil => ()
+        case (earlierName, earlierSub) :: laters =>
+          laters.foreach: (laterName, laterSub) =>
+            if laterSub.subset(earlierSub) then throw ShadowException(laterName, earlierName)

--- a/test/src/alpaca/internal/lexer/RegexCheckerTest.scala
+++ b/test/src/alpaca/internal/lexer/RegexCheckerTest.scala
@@ -2,6 +2,8 @@ package alpaca
 package internal
 package lexer
 
+import alpaca.internal.lexer.regex.{Regex, RegexParser}
+
 import org.scalatest.LoneElement
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -9,84 +11,118 @@ import org.scalatest.matchers.should.Matchers
 final class RegexCheckerTest extends AnyFunSuite with Matchers with LoneElement:
   private given DebugSettings = DebugSettings.default
 
-  test("checkPatterns should return None for non-overlapping patterns") {
+  private def items(patterns: String*): List[(name: String, regex: Regex)] =
+    patterns.toList.map: p =>
+      RegexParser.parse(p) match
+        case Right(r) => (name = p, regex = r)
+        case Left(err) => fail(s"expected successful parse of /$p/, got $err")
+
+  test("checkRegexes should pass for non-overlapping patterns") {
     withLog:
-      val patterns = List(
-        "[a-zA-Z_][a-zA-Z0-9_]*",
-        "[+-]?[0-9]+",
-        "=",
-        "[ \\t\\n]+",
-      )
       noException shouldBe thrownBy:
-        RegexChecker.checkPatterns(patterns)
+        RegexChecker.checkRegexes(
+          items(
+            "[a-zA-Z_][a-zA-Z0-9_]*",
+            "[+-]?[0-9]+",
+            "=",
+            "[ \\t\\n]+",
+          ),
+        )
   }
 
-  test("checkPatterns should throw ShadowException for overlapping patterns") {
+  test("checkRegexes should throw ShadowException for overlapping patterns") {
     withLog:
-      val patterns = List(
-        "[a-zA-Z_][a-zA-Z0-9_]*",
-        "\\*",
-        "=",
-        "[a-zA-Z]+",
-        "[ \\t\\n]+",
-      )
       intercept[ShadowException]:
-        RegexChecker.checkPatterns(patterns)
+        RegexChecker.checkRegexes(
+          items(
+            "[a-zA-Z_][a-zA-Z0-9_]*",
+            "\\*",
+            "=",
+            "[a-zA-Z]+",
+            "[ \\t\\n]+",
+          ),
+        )
       .getMessage should include("Pattern [a-zA-Z]+ is shadowed by [a-zA-Z_][a-zA-Z0-9_]*")
   }
 
-  test("checkPatterns should report prefix shadowing") {
+  test("checkRegexes should report prefix shadowing") {
     withLog:
-      val patterns = List(
-        "i",
-        "\\*",
-        "if",
-        "=",
-        "[a-zA-Z]+",
-        "[ \\t\\n]+",
-      )
       intercept[ShadowException]:
-        RegexChecker.checkPatterns(patterns)
+        RegexChecker.checkRegexes(
+          items(
+            "i",
+            "\\*",
+            "if",
+            "=",
+            "[a-zA-Z]+",
+            "[ \\t\\n]+",
+          ),
+        )
       .getMessage should include("Pattern if is shadowed by i")
   }
 
-  test("checkPatterns should report identical patterns as overlapping") {
+  test("checkRegexes should report identical patterns as overlapping") {
     withLog:
-      val patterns = List(
-        "[a-zA-Z_][a-zA-Z0-9_]*",
-        "\\*",
-        "=",
-        "[a-zA-Z_][a-zA-Z0-9_]*",
-        "[ \\t\\n]+",
-      )
       intercept[ShadowException]:
-        RegexChecker.checkPatterns(patterns)
+        RegexChecker.checkRegexes(
+          items(
+            "[a-zA-Z_][a-zA-Z0-9_]*",
+            "\\*",
+            "=",
+            "[a-zA-Z_][a-zA-Z0-9_]*",
+            "[ \\t\\n]+",
+          ),
+        )
       .getMessage should include("Pattern [a-zA-Z_][a-zA-Z0-9_]* is shadowed by [a-zA-Z_][a-zA-Z0-9_]*")
   }
 
-  test("checkPatterns should not report patterns in proper order") {
+  test("checkRegexes should not report patterns in proper order") {
     withLog:
-      val patterns = List(
-        "if",
-        "\\*",
-        "when",
-        "i",
-        "=",
-        "[a-zA-Z_][a-zA-Z0-9_]*",
-        "[ \\t\\n]+",
-      )
       noException shouldBe thrownBy:
-        RegexChecker.checkPatterns(patterns)
+        RegexChecker.checkRegexes(
+          items(
+            "if",
+            "\\*",
+            "when",
+            "i",
+            "=",
+            "[a-zA-Z_][a-zA-Z0-9_]*",
+            "[ \\t\\n]+",
+          ),
+        )
   }
 
-  test("checkPatterns should handle empty pattern list") {
+  test("checkRegexes should handle empty pattern list") {
     withLog:
       noException shouldBe thrownBy:
-        RegexChecker.checkPatterns(Nil)
+        RegexChecker.checkRegexes(Nil)
   }
 
-  test("checkPatterns should handle single pattern") {
+  test("checkRegexes should handle single pattern") {
     withLog:
       noException shouldBe thrownBy:
-        RegexChecker.checkPatterns(List("[a-zA-Z_][a-zA-Z0-9_]*"))
+        RegexChecker.checkRegexes(items("[a-zA-Z_][a-zA-Z0-9_]*"))
+  }
+
+  test("handles CalcLexer-like patterns") {
+    withLog:
+      noException shouldBe thrownBy:
+        RegexChecker.checkRegexes(
+          items(
+            " ",
+            "\\t",
+            "[a-zA-Z_][a-zA-Z0-9_]*",
+            "\\+",
+            "-",
+            "\\*",
+            "/",
+            "=",
+            ",",
+            "\\(",
+            "\\)",
+            "\\d+",
+            "#.*",
+            "\n+",
+          ),
+        )
   }


### PR DESCRIPTION
## Summary
- Replaces `dregex`-based shadow detection with the internal `Subset` machinery introduced in #388
- `RegexChecker.checkRegexes(List[(name, Regex)])` now operates on pre-parsed regexes; callers parse upfront and propagate errors via `report.errorAndAbort`
- `CompileNameAndPattern` parses alternation patterns via `RegexParser` and keeps the per-alternation shadow check (forward + reverse) intact
- `Lexer` macro parses all token patterns once via `RegexParser` and runs a single global shadow check
- `build.mill` drops the `dregex` mvnDep

## Why
Second step of the `Native` milestone. Eliminates the JVM-only `dregex` dependency so the lexer no longer needs Java reflection / JVM regex for shadow analysis. The runtime matcher still uses `java.util.regex.Pattern` — that goes away in the next PR.

## Base
Stacks on top of #388 (cross-platform regex algebra). Merge order: #388 first, then this.

## Test plan
- [x] `./mill compile` passes
- [x] `./mill test` passes (RegexCheckerTest covers the new API; existing LexerTest/LexerApiTest stay green)
- [ ] Confirm CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)