### PR TITLE
refactor(lexer): replace java.util.regex with internal DFA driver

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -85,12 +85,6 @@ object `package` extends ScalaModule with ScoverageModule with SonatypeCentralPu
     ),
   )
 
-  def mvnDeps = Seq(
-    mvn"org.jparsec:jparsec:3.1",
-    mvn"org.slf4j:slf4j-api:2.0.17",
-    mvn"org.slf4j:slf4j-simple:2.0.17",
-  )
-
   object test extends ScalaTests with TestModule.ScalaTest with ScoverageTests:
     def scalaTestVersion = "3.2.19"
 

--- a/src/alpaca/internal/lexer/Lexer.scala
+++ b/src/alpaca/internal/lexer/Lexer.scala
@@ -3,9 +3,8 @@ package internal
 package lexer
 
 import alpaca.Token as TokenDef
-import alpaca.internal.lexer.regex.{Regex, RegexParseError, RegexParser}
+import alpaca.internal.lexer.regex.{Regex, RegexParseError, RegexParser, TokenMatcher}
 
-import java.util.regex.{Pattern, PatternSyntaxException}
 import scala.NamedTuple.{AnyNamedTuple, NamedTuple}
 import scala.annotation.{publicInBinary, switch}
 import scala.reflect.NameTransformer
@@ -152,20 +151,7 @@ def lexerImpl[Ctx <: LexerCtx: Type, lexemeFields <: AnyNamedTuple: Type](
   (refinementTpeFrom(fields).asType, fieldsTpeFrom(fields).asType, types.asType).runtimeChecked match
     case ('[refinedTpe], '[fields], '[types]) =>
       val tokensExpr = Expr.ofList(tokens.map(_.expr))
-      infos.foreach: info =>
-        try Pattern.compile(info.pattern)
-        catch
-          case e: PatternSyntaxException =>
-            report.errorAndAbort(
-              show"Invalid regex pattern \"${info.pattern}\" for token \"${info.name}\": ${e.getDescription}. If you meant to match a literal character, escape it with a backslash (e.g., \"\\\\+\" instead of \"+\")",
-            )
-
-      val regex = Expr:
-        infos
-          .map:
-            case TokenInfo(_, regexGroupName, pattern) => show"(?<$regexGroupName>$pattern)"
-          .mkString("|")
-          .tap(Pattern.compile) // we'd like to compile it here to fail in compile time if regex is invalid
+      val matcherExpr = '{ TokenMatcher.fromRegexes(${ Varargs(parsedRegexes.map(Expr(_))) }*) }
 
       '{
         {
@@ -175,7 +161,7 @@ def lexerImpl[Ctx <: LexerCtx: Type, lexemeFields <: AnyNamedTuple: Type](
 
             override def selectDynamic(name: String): Token[?, Ctx, ?] = ${ selectDynamicImpl('{ name }) }
 
-            override protected val compiled: java.util.regex.Pattern = Pattern.compile($regex)
+            override protected val matcher: TokenMatcher = $matcherExpr
         }.asInstanceOf[Tokenization[Ctx] { type LexemeFields = lexemeFields; type Fields = fields } & refinedTpe & types]
       }
 // $COVERAGE-ON$

--- a/src/alpaca/internal/lexer/Tokenization.scala
+++ b/src/alpaca/internal/lexer/Tokenization.scala
@@ -3,12 +3,11 @@ package internal
 package lexer
 
 import alpaca.internal.lexer.ErrorHandling.Strategy
+import alpaca.internal.lexer.regex.TokenMatcher
 
 import scala.NamedTuple.{AnyNamedTuple, NamedTuple}
 import scala.annotation.publicInBinary
 import scala.collection.mutable
-import scala.util.boundary
-import scala.util.boundary.break
 
 /**
  * The result of compiling a lexer definition.
@@ -56,44 +55,44 @@ transparent abstract class Tokenization[Ctx <: LexerCtx](
     val globalCtx = empty()
     globalCtx.text = OffsetCharSequence(input)
 
-    val matcher = compiled.matcher(globalCtx.text)
     val acc = mutable.ListBuffer.empty[Lexeme]
 
     while !globalCtx.text.isEmpty do
-      matcher.reset(globalCtx.text)
+      val (token, matched) = matcher.matchAt(globalCtx.text, 0) match
+        case Some((priority, end)) if end > 0 =>
+          val matchedStr = globalCtx.text.subSequence(0, end).toString
+          globalCtx.lastRawMatched = matchedStr
+          val found = tokensArray(priority)
+          globalCtx.text = globalCtx.text.from(end)
+          (found, matchedStr)
 
-      // noinspection ScalaUnreachableCode
-      val (token, matched) = if matcher.lookingAt then
-        val matched = matcher.group(0)
-        globalCtx.lastRawMatched = matched
-        globalCtx.text = globalCtx.text.from(matcher.end)
+        case _ =>
+          errorHandling(globalCtx) match
+            case Strategy.Throw(ex) =>
+              throw ex
 
-        val found = boundary:
-          for i <- 1 to matcher.groupCount if matcher.start(i) != -1 do break(groupToTokenMap(i))
-          throw AlgorithmError(s"${matcher.pattern} matched but no token defined for it")
+            case Strategy.IgnoreToken =>
+              matcher.findFirst(globalCtx.text, 1) match
+                case Some((firstMatching, _, _)) =>
+                  val matchedStr = globalCtx.text.subSequence(0, firstMatching).toString
+                  globalCtx.lastRawMatched = matchedStr
+                  globalCtx.text = globalCtx.text.from(firstMatching)
+                  (RecoveredToken(matchedStr), matchedStr)
+                case None =>
+                  val matchedStr = globalCtx.text.charAt(0).toString
+                  globalCtx.lastRawMatched = matchedStr
+                  globalCtx.text = globalCtx.text.from(1)
+                  (RecoveredToken(matchedStr), matchedStr)
 
-        (found, matched)
-      else
-        errorHandling(globalCtx) match
-          case Strategy.Throw(ex) =>
-            throw ex
+            case Strategy.IgnoreChar =>
+              val matchedStr = globalCtx.text.charAt(0).toString
+              globalCtx.lastRawMatched = matchedStr
+              globalCtx.text = globalCtx.text.from(1)
+              (RecoveredToken(matchedStr), matchedStr)
 
-          case Strategy.IgnoreToken if matcher.find =>
-            val firstMatching = matcher.start
-            val matched = globalCtx.text.subSequence(0, firstMatching).toString
-            globalCtx.lastRawMatched = matched
-            globalCtx.text = globalCtx.text.from(firstMatching)
-            (RecoveredToken(matched), matched)
-
-          case Strategy.IgnoreChar | Strategy.IgnoreToken =>
-            val matched = globalCtx.text.charAt(0).toString
-            globalCtx.lastRawMatched = matched
-            globalCtx.text = globalCtx.text.from(1)
-            (RecoveredToken(matched), matched)
-
-          case Strategy.Stop =>
-            globalCtx.text = ""
-            (null, null)
+            case Strategy.Stop =>
+              globalCtx.text = ""
+              (null, null)
 
       if token != null && matched != null then
         betweenStages(token, matched, globalCtx)
@@ -101,18 +100,10 @@ transparent abstract class Tokenization[Ctx <: LexerCtx](
 
     (globalCtx, acc.toList)
 
-  /** The compiled pattern that matches all defined tokens. */
-  protected def compiled: java.util.regex.Pattern
+  /** Compiled token-matcher; built at macro time. */
+  protected def matcher: TokenMatcher
 
-  private lazy val groupToTokenMap: Array[Token[?, Ctx, ?]] =
-    val matcher = compiled.matcher("")
-    val totalGroups = matcher.groupCount
-    val map = new Array[Token[?, Ctx, ?]](totalGroups + 1)
-
-    tokens.foreach: token =>
-      val groupIndex = compiled.namedGroups.get(token.info.regexGroupName)
-      if groupIndex != null then map(groupIndex) = token
-    map
+  private lazy val tokensArray: Vector[Token[?, Ctx, ?]] = tokens.toVector
 
 extension (input: CharSequence)
   private[alpaca] def from(pos: Int): CharSequence = input match

--- a/src/alpaca/internal/lexer/regex/TokenMatcher.scala
+++ b/src/alpaca/internal/lexer/regex/TokenMatcher.scala
@@ -1,0 +1,55 @@
+package alpaca
+package internal
+package lexer
+package regex
+
+/**
+ * Lexer-style longest-match tokenizer over a priority-ordered list of patterns.
+ *
+ * Simulates a tagged Brzozowski-derivative DFA in parallel for all patterns. Returns
+ * the longest prefix match across all patterns; ties broken by lowest priority index
+ * (i.e., the first pattern in the input list wins).
+ */
+opaque private[lexer] type TokenMatcher = Vector[Subset]
+
+private[lexer] object TokenMatcher:
+
+  /** Build a matcher from pre-parsed regexes (use this from macros after compile-time parsing). */
+  def fromRegexes(initial: Regex*): TokenMatcher = initial.iterator.map(Subset.of).toVector
+
+  extension (m: TokenMatcher)
+
+    /**
+     * Match a token starting at `start` in `input`.
+     *
+     * @return `Some((priority, end))` where `priority` is the index of the winning
+     *         pattern and `end` is the exclusive end of the longest match. `None` if
+     *         no pattern matches any (possibly empty) prefix at `start`.
+     */
+    def matchAt(input: CharSequence, start: Int): Option[(priority: Int, end: Int)] =
+      codePointStarts(input, start)
+        .map(p => (Character.codePointAt(input, p), p))
+        .scanLeft((m, start)):
+          case ((st, _), (c, p)) => (st.map(_.derive(c)), p + Character.charCount(c))
+        .takeWhile((st, _) => !st.allEmpty)
+        .flatMap((st, p) => st.firstNullable.map(idx => (priority = idx, end = p)))
+        .foldLeft(Option.empty[(priority: Int, end: Int)])((_, hit) => Some(hit))
+
+    /** First position `>= from` at which some pattern matches a non-empty prefix. */
+    def findFirst(input: CharSequence, from: Int): Option[(start: Int, priority: Int, end: Int)] =
+      codePointStarts(input, from)
+        .map(start => (start, m.matchAt(input, start)))
+        .collectFirst:
+          case (start, Some((priority, end))) if end > start => (start, priority, end)
+
+  /** Iterator of code-point start offsets in `input`, beginning at `from`. */
+  private def codePointStarts(input: CharSequence, from: Int): Iterator[Int] =
+    Iterator
+      .iterate(from)(p => p + Character.charCount(Character.codePointAt(input, p)))
+      .takeWhile(_ < input.length)
+
+  extension (s: Vector[Subset])
+    private def firstNullable: Option[Int] = s.iterator.zipWithIndex.collectFirst:
+      case (sub, idx) if sub.nullable => idx
+
+    private def allEmpty: Boolean = s.forall(_ == Subset.empty)

--- a/test/src/alpaca/internal/lexer/ErrorHandlingStrategyTest.scala
+++ b/test/src/alpaca/internal/lexer/ErrorHandlingStrategyTest.scala
@@ -4,8 +4,6 @@ package internal.lexer
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
-import java.util.regex.Pattern
-
 final class ErrorHandlingStrategyTest extends AnyFunSuite with Matchers:
 
   test("Strategy.Throw should throw the provided exception") {


### PR DESCRIPTION
Replaces #390 which was accidentally auto-closed during a botched rebase cascade. Same commits.

Stacks on #389. Drops the runtime use of java.util.regex; adds an internal Brzozowski-derivative driver (TokenMatcher) with lazy state interning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)