### PR TITLE
build(mill): split into jvm and native modules

### DIFF
--- a/.github/workflows/test-compilation-benchmark.yml
+++ b/.github/workflows/test-compilation-benchmark.yml
@@ -55,7 +55,7 @@ jobs:
             (
               cd "$dir"
           
-              hyperfine --runs 5 --prepare "./mill clean && ./mill compile" "./mill test.compile" --export-json "../${dir}.json"
+              hyperfine --runs 5 --prepare "./mill clean && ./mill __.compile" "./mill __.test.compile" --export-json "../${dir}.json"
             )
             echo "::endgroup::"
           }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,23 +38,23 @@ jobs:
             ${{ runner.os }}-mill-
 
       - name: Compile
-        run: ./mill compile
+        run: ./mill __.compile
 
       - name: Compile tests
         run: |
           echo "Starting test compilation..."
           START_TIME=$(date +%s)
-          ./mill test.compile
+          ./mill __.test.compile
           END_TIME=$(date +%s)
           DURATION=$((END_TIME - START_TIME))
           echo "Test compilation completed in ${DURATION}s"
           echo "TEST_COMPILE_TIME=${DURATION}" >> $GITHUB_ENV
 
       - name: Run tests
-        run: ./mill test
+        run: ./mill __.test
 
       - name: Code coverage
-        run: ./mill scoverage.xmlCoberturaReport
+        run: ./mill jvm.scoverage.xmlCoberturaReport
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v6
@@ -66,7 +66,7 @@ jobs:
         run: ./mill mill.scalalib.scalafmt/checkFormatAll
 
       - name: Generate Docs
-        run: ./mill docJar
+        run: ./mill jvm.docJar
 
       - name: Report Test Compilation Time
         if: always()

--- a/build.mill
+++ b/build.mill
@@ -1,4 +1,4 @@
-//| mill-version: 1.1.6
+//| mill-version: 1.1.5
 //| mill-jvm-version: 21
 //| mvnDeps:
 //| - com.lihaoyi::mill-contrib-scoverage:$MILL_VERSION
@@ -10,83 +10,94 @@ package build
 import mill.*
 import mill.scalalib.*
 import mill.scalalib.publish.*
+import mill.scalanativelib.*
 import mill.contrib.scoverage.ScoverageModule
 import mill.contrib.jmh.JmhModule
 import mill.util.VcsVersion
 
-object `package` extends ScalaModule with ScoverageModule with SonatypeCentralPublishModule:
-  def scalaVersion = "3.8.3-RC1"
+object `package` extends Module:
 
-  def scoverageVersion = "2.5.2"
+  trait Shared extends ScalaModule with PlatformScalaModule with SonatypeCentralPublishModule:
+    def scalaVersion = "3.8.3-RC1"
 
-  override def scalacOptions = Seq(
-    "-deprecation",
-    "-feature",
-    // "-explain",
-    "-new-syntax",
-    "-unchecked",
-    "-language:noAutoTupling",
-    "-Vprofile",
-    "-Xprint-inline",
-    // "-Ycheck:all", // cannot be enabled when scoverage used :/
-    "-Ycheck:macros",
-    // "-Ydebug-error",
-    "-Ydebug-flags",
-    "-Ydebug-missing-refs",
-    "-Yexplain-lowlevel",
-    "-Yexplicit-nulls",
-    // "-Yprint-debug",
-    // "-Xprint:postInlining",
-    // "-Xprint-suspension",
-    // "-Vprint:typer",
-    "-Wsafe-init",
-    "-Yshow-suppressed-errors",
-    "-Yshow-var-bounds",
-    "-Werror",
-    "-Wunused:all",
-    "-experimental",
-    "-preview",
-    s"-Xmacro-settings:debugDirectory=$moduleDir/debug,enableVerboseNames=true",
-    // "-Xmacro-settings:trace=file",
-    //  "-Yprofile-enabled",
-    //  s"-Yprofile-trace:$moduleDir/debug/compile-trace.json",
-  )
-
-  override def scalaDocOptions = Task {
-    Seq(
-      "-project",
-      "alpaca",
-      "-project-version",
-      publishVersion(),
-      "-project-logo",
-      s"$moduleDir/docs/_assets/images/logo.png",
-      "-project-footer",
-      "made with ❤️ and coffee",
-      "-social-links:github::https://github.com/halotukozak/alpaca",
-      "-snippet-compiler:compile",
-      s"-source-links:$moduleDir=github://halotukozak/alpaca/master",
-      "-revision:master",
+    override def scalacOptions = Seq(
+      "-deprecation",
+      "-feature",
+      // "-explain",
+      "-new-syntax",
+      "-unchecked",
+      "-language:noAutoTupling",
+      "-Vprofile",
+      "-Xprint-inline",
+      // "-Ycheck:all", // cannot be enabled when scoverage used :/
+      "-Ycheck:macros",
+      // "-Ydebug-error",
+      "-Ydebug-flags",
+      "-Ydebug-missing-refs",
+      "-Yexplain-lowlevel",
+      "-Yexplicit-nulls",
+      // "-Yprint-debug",
+      // "-Xprint:postInlining",
+      // "-Xprint-suspension",
+      // "-Vprint:typer",
+      "-Wsafe-init",
+      "-Yshow-suppressed-errors",
+      "-Yshow-var-bounds",
+      "-Werror",
+      "-Wunused:all",
+      "-experimental",
+      "-preview",
+      s"-Xmacro-settings:debugDirectory=$moduleDir/debug,enableVerboseNames=true",
+      // "-Xmacro-settings:trace=file",
+      //  "-Yprofile-enabled",
+      //  s"-Yprofile-trace:$moduleDir/debug/compile-trace.json",
     )
-  }
 
-  def artifactName = "alpaca"
+    override def scalaDocOptions = Task {
+      Seq(
+        "-project",
+        "alpaca",
+        "-project-version",
+        publishVersion(),
+        "-project-logo",
+        s"$moduleDir/docs/_assets/images/logo.png",
+        "-project-footer",
+        "made with ❤️ and coffee",
+        "-social-links:github::https://github.com/halotukozak/alpaca",
+        "-snippet-compiler:compile",
+        s"-source-links:$moduleDir=github://halotukozak/alpaca/master",
+        "-revision:master",
+      )
+    }
 
-  def publishVersion = Task(VcsVersion.vcsState().format())
+    def artifactName = "alpaca"
 
-  def pomSettings = PomSettings(
-    description = "Another Lexer Parser And Compiler Alpaca",
-    organization = "io.github.halotukozak",
-    url = "https://halotukozak.github.io/alpaca/docs/index.html",
-    licenses = Seq(License.MIT),
-    versionControl = VersionControl.github("halotukozak", "alpaca"),
-    developers = Seq(
-      Developer("halotukozak", "Bartłomiej Kozak", "https://github.com/halotukozak"),
-      Developer("Corvette653", "Bartosz Buczek", "https://github.com/Corvette653"),
-    ),
-  )
+    def publishVersion = Task(VcsVersion.vcsState().format())
 
-  object test extends ScalaTests with TestModule.ScalaTest with ScoverageTests:
-    def scalaTestVersion = "3.2.19"
+    def pomSettings = PomSettings(
+      description = "Another Lexer Parser And Compiler Alpaca",
+      organization = "io.github.halotukozak",
+      url = "https://halotukozak.github.io/alpaca/docs/index.html",
+      licenses = Seq(License.MIT),
+      versionControl = VersionControl.github("halotukozak", "alpaca"),
+      developers = Seq(
+        Developer("halotukozak", "Bartłomiej Kozak", "https://github.com/halotukozak"),
+        Developer("Corvette653", "Bartosz Buczek", "https://github.com/Corvette653"),
+      ),
+    )
+
+  object jvm extends Shared with ScoverageModule:
+
+    def scoverageVersion = "2.5.2"
+
+    object test extends ScalaTests with TestModule.ScalaTest with ScoverageTests:
+      def scalaTestVersion = "3.2.19"
+
+  object native extends Shared with ScalaNativeModule:
+    def scalaNativeVersion = "0.5.10"
+
+    object test extends ScalaTests with TestModule.ScalaTest with ScalaNativeTests:
+      def scalaTestVersion = "3.2.19"
 
   object benchmarks extends Module:
 
@@ -96,9 +107,9 @@ object `package` extends ScalaModule with ScoverageModule with SonatypeCentralPu
       override def forkWorkingDir = Task(moduleDir / os.up)
 
     object alpaca extends BenchmarkScalaModule with JmhModule:
-      def scalaVersion = build.scalaVersion()
+      def scalaVersion = build.jvm.scalaVersion()
       override def scalacOptions = Seq("-experimental", "-preview", "-Yretain-trees")
-      def moduleDeps = Seq(build)
+      def moduleDeps = Seq(build.jvm)
 
     object fastparse extends BenchmarkScalaModule:
       def scalaVersion = "3.8.3"


### PR DESCRIPTION
Replaces #391 (auto-closed during botched rebase cascade). Same commits.