### PR TITLE
chore: use canonical secret names

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,9 +18,19 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+      # Mill's SonatypeCentralPublishModule hardcodes MILL_PGP_SECRET_BASE64 and expects
+      # base64, while PGP_PRIVATE_KEY (shared with the scala-cli/Gradle publish workflows)
+      # is stored armored -- derive the base64 form at runtime instead of keeping a second
+      # copy of the key around.
+      - name: Derive MILL_PGP_SECRET_BASE64 from PGP_PRIVATE_KEY
+        env:
+          PGP_PRIVATE_KEY: ${{ secrets.PGP_PRIVATE_KEY }}
+        run: |
+          encoded="$(printf '%s' "$PGP_PRIVATE_KEY" | base64 -w0)"
+          echo "::add-mask::$encoded"
+          echo "MILL_PGP_SECRET_BASE64=$encoded" >> "$GITHUB_ENV"
       - run: ./mill mill.javalib.SonatypeCentralPublishModule/
         env:
-          MILL_PGP_PASSPHRASE: ${{ secrets.MILL_PGP_PASSPHRASE }}
-          MILL_PGP_SECRET_BASE64: ${{ secrets.MILL_PGP_SECRET_BASE64 }}
-          MILL_SONATYPE_PASSWORD: ${{ secrets.MILL_SONATYPE_PASSWORD }}
-          MILL_SONATYPE_USERNAME: ${{ secrets.MILL_SONATYPE_USERNAME }}
+          MILL_PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          MILL_SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          MILL_SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}


### PR DESCRIPTION
Unifies secret references with the org-wide canonical set from
https://halotukozak.github.io/posts/scala-cli-e2e/ (SONATYPE_USERNAME,
SONATYPE_PASSWORD, PGP_PRIVATE_KEY, PGP_PASSPHRASE), now provided as
org-level Actions secrets shared across mcodec/made/sure/alpaca.

Mill's SonatypeCentralPublishModule hardcodes the `MILL_PGP_SECRET_BASE64`
env var name and expects base64, while the shared `PGP_PRIVATE_KEY` is
stored armored -- added a step that derives the base64 form at runtime
(masked via `::add-mask::`) instead of keeping a second copy of the key.

**Do not merge until the org secrets exist and a real (or dry-run) publish
has been verified** -- the repo-level MILL_* secrets this replaces are
still in place as a fallback until then.