### PR TITLE
ci: don't hard-fail on Codecov upload errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,7 +60,8 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          slug: halotukozak/alpaca
+          slug: halotukozak-com/alpaca
+          fail_ci_if_error: false
 
       - name: ScalaFmt
         run: ./mill mill.scalalib.scalafmt/checkFormatAll


### PR DESCRIPTION
scala-steward opens PRs from a fork, so GitHub Actions withholds CODECOV_TOKEN (and every other secret) from those runs by design. codecov-action defaults to failing the job on upload errors, which would turn every scala-steward PR's required check red over an unrelated coverage-upload failure -- also blocking auto-merge. Also fixes the slug, still pointing at the old halotukozak/alpaca (pre-org-move) instead of halotukozak-com/alpaca.